### PR TITLE
Add support for API 1.4 endpoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,17 @@
     ],
     "require": {
         "php": "^8.1",
-        "jane-php/open-api-runtime": "^7.9"
+        "jane-php/open-api-runtime": "^7.9",
+        "nyholm/psr7": "^1.8"
     },
     "require-dev": {
-        "jane-php/open-api-3": "dev-fixes as 7.9.0",
-        "jane-php/json-schema": "dev-bugfix/array-objects as 7.9.0",
-        "jane-php/open-api-common": "dev-next as 7.9.0",
+        "jane-php/jane-php": "dev-next",
         "friendsofphp/php-cs-fixer": "^3.75"
     },
     "repositories": [
         {
             "type": "vcs",
-            "url": "git@github.com:silverstripeltd/jane-php-json-schema.git"
-        },
-        {
-            "type": "vcs",
-            "url": "git@github.com:silverstripeltd/jane-php-open-api-3.git"
+            "url": "https://github.com/janephp/janephp.git"
         }
     ],
     "extra": {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1,1 +1,5554 @@
-{"openapi":"3.1.0","info":{"title":"Bifröst","description":"\nBifröst API 🌈\n\nManaged search for Silverstripe Cloud\n","termsOfService":"http://https://silverstripe.com/search#terms","contact":{"name":"Silverstripe Ltd","url":"https://silverstripe.com/search","email":"search@silverstripe.com"},"version":"1.0.0"},"servers":[{"url":"/api/v1"}],"paths":{"/{engine_name}/documents":{"post":{"tags":["documents"],"summary":"Post Documents","description":"Create or update documents.\n\nDocuments are indexed asynchronously. There will be a processing delay before they are available to your Engine.\n\n**Key points to remember when creating documents:**\n\n* It is recommended that you provide your own `id` field, but If no `id` is provided, a unique `id` will be\n  generated.\n* A new document is created each time content is received without an `id` - beware duplicates!\n* A document will be updated - not created - if its `id` already exists within a document.\n\n**Processing file contents**\n\n* An `_attachment` field can be used to attach PDF and Docx files to your document.\n* The _attachment` field should contain a base 64 encoded string of binary.","operationId":"documents_post","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"array","items":{"type":"object","additionalProperties":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"}]}}]},"examples":[{"id":"silverstripe_cms_model_sitetree_1","title":"Auckland Zoo","term_ids":[1,2,5],"location":"-36.8639680119916, 174.7199894180399","last_edited":"2024-06-14T13:53:44+12:00"}]},"title":"Documents"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/DocumentPostPatchResponse"},"title":"Response Documents Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"patch":{"tags":["documents"],"summary":"Patch Documents","description":"Update specific document fields by `id` and `field`.\n\nThere are a couple of limitations of the PATCH action:\n- The `id` is required and new fields cannot be created using `PATCH`!\n- processing file content is **not supported** via PATCH","operationId":"documents_patch","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"array","items":{"type":"object","additionalProperties":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"}]}}]},"examples":[{"id":"silverstripe_cms_model_sitetree_1","title":"Auckland Zoo","term_ids":[1,2,5],"location":"-36.8639680119916, 174.7199894180399","last_edited":"2024-06-14T13:53:44+12:00"}]},"title":"Documents"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/DocumentPostPatchResponse"},"title":"Response Documents Patch"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["documents"],"summary":"Delete Documents","description":"Delete documents by `id`.","operationId":"documents_delete","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"array","items":{"type":"string"},"examples":[["park_zion","park_yosemite","does_not_exist"]],"title":"Document Ids"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/DocumentsDeleteResponse"},"title":"Response Documents Delete"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"get":{"tags":["documents"],"summary":"Get Documents","description":"A paginated array of JSON objects representing documents.\n\n**Query parameters:**\n\n`ids` **(required)**\n* A parameterized query of document `id`. EG: ids=zion_park&ids=does_not_exist","operationId":"documents_get","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"type":"array","items":{"type":"string"},"examples":[["park_zion","park_yosemite","does_not_exist"]],"title":"Document Ids"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/Document"},"title":"Response Documents Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/{engine_name}/documents/list":{"post":{"tags":["documents"],"summary":"Post Documents List","description":"**Body:**\n\n`page` (optional)\n* Object to delimit the pagination parameters.\n\n`page.size` (optional)\n* Number of results per page.\n* Must be greater than or equal to 1 and less than or equal to 100.\n* Defaults to 10.\n\n`page.current` (optional)\n* Page number of results to return.\n* Must be greater than or equal to 1 and less than or equal to 100.\n* Defaults to 1.","operationId":"documents_list_post","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"content":{"application/json":{"schema":{"anyOf":[{"$ref":"#/components/schemas/DocumentListRequest"},{"type":"null"}],"default":{"page":{"current":1,"size":10}},"title":"Body"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/DocumentListResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/engines":{"post":{"tags":["engines"],"summary":"Post Engines","operationId":"engines_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/EnginesResponse"}}}},"404":{"description":"Not found"}},"security":[{"HTTPBearer":[]}]}},"/{engine_name}/query_suggestion":{"post":{"tags":["search"],"summary":"Post Query Suggestion","description":"Provide relevant query suggestions for incomplete queries. Also known as Autocomplete.\n\nOnly available on text fields.\n\n**Body:**\n\n`query` **(required)**\n* A partial query for which to receive suggestions.\n\n`types` (optional)\n* Specify the documents key within the types parameter to look for suggestions within certain text fields. Defaults to all text fields.\n\n`size` (optional)\n* Number of query suggestions to return. Must be between 1 and 20. Defaults to 10.","operationId":"query_suggestion_post","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/QuerySuggestionRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/QuerySuggestionResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/{engine_name}/schema":{"get":{"tags":["configuration"],"summary":"Get Schema","operationId":"schema_get","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Schema"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["configuration"],"summary":"Post Schema","description":"**Field types:**\n\n* `text`\n* `number`\n* `date`\n    * Strings containing formatted dates, e.g. \"2015-01-01\" or \"2015/01/01 12:10:30\".\n    * A number representing seconds-since-the-epoch.\n* `geolocation`\n\n**Field names:**\n\n* Must contain a lowercase letter and may only contain lowercase letters, numbers, and underscores.\n* Must not contain whitespace or have a leading underscore.\n* Must not contain more than 64 characters.\n* Must not be any of the following reserved words:\n    * `id`\n    * `engine_id`\n    * `search_index_id`\n    * `highlight`\n    * `any`\n    * `all`\n    * `none`\n    * `or`\n    * `and`\n    * `not`\n* The following fields can be used, but must be of type `text`\n    * `body`\n* The following fields can be used, but must be of type `binary`\n    * `_attachment`","operationId":"schema_post","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/Schema"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SchemaPostResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/{engine_name}/search":{"post":{"tags":["search"],"summary":"Post Search","description":"Submit a search and receive a set of results with metadata.\n\n**Body:**\n\n`query` **(required)**\n* String or number to match\n* The value '' (empty string) matches all documents\n* The following Lucene query syntax is supported:\n    * double-quoted strings\n    * `+` and `-`\n    * `AND` and `NOT`\n\n`page` (optional)\n* Object to delimit the pagination parameters.\n\n`page.size` (optional)\n* Number of results per page\n* Must be greater than or equal to 1 and less than or equal to 100\n* Defaults to 10.\n\n`page.current` (optional)\n* Page number of results to return\n* Must be greater than or equal to 1 and less than or equal to 100\n* Defaults to 1.\n\n`sort` (optional)\n* Sort your results in an order other than document score\n* JSON object where the key is the field you wish to sort on, and the value is `asc` or `desc`\n* Multiple keys/value pairs can be provided if you wish to sort against multiple fields\n* The following sorting options are available based on field type:\n    * `text`: Alphanumerically, case-sensitive\n    * `number`: Numerically\n    * `date`: Historically\n    * `geolocation`: By distance to a provided geographical point.\n\n`facets` (optional)\n* Create value and range facets\n* The facets key opens up the object where you define your facet field\n* The following facet types are available based on field type:\n    * `text`: Value facet\n    * `number`: Value facet, Range facet\n    * `date`: Value facet, Range facet\n    * `geolocation`: Currently unsupported\n\n`facets.{field_key}` **(required)**\n* The field from your schema upon which to apply your facet\n* Must contain an array of {facet_object}.\n\n`{facet_object}.type` **(required)**\n* Type of facet, one of either \"value\" or \"range\".\n\n`{facet_object}.name` (optional)\n* Name given to facet.\n\nValue facet:\n\n`{facet_object}.size` (optional)\n* How many facets would you like to return?\n* Can be between 1 and 100\n* Defaults to 10.\n\n`{facet_object}.sort` (optional)\n* JSON object where the key is either `count` or `value` and the value is `asc` or `desc`.\n* Defaults to descending `count`.\n\nRange facet:\n\n`{facet_object}.ranges` **(required)**\n* An array of {facet_range_object}.\n\n`{facet_range_object}.name` (optional)\n* A name given to the range.\n\n`{facet_range_object}.from` (optional)\n* Inclusive lower bound of the range. Is required if to is not given.\n\n`{facet_range_object}.to` (optional)\n* Exclusive upper bound of the range. Is required if from is not given.\n\n`filters` (optional)\n* Apply conditions to field values to filter results\n* The following filters are available based on field type:\n    * `text`: Value filter\n    * `number`: Value filter, Range filter\n    * `date`: Value filter, Range filter\n    * `geolocation`: Geo filter\n\n`search_fields` (optional)\n* The search_fields parameter restricts a query to search only specific fields\n* Restricting fields will result in faster queries, especially for schemas with many text fields\n* Only available within text fields.\n\n`search_field.{field_key}` **(required)**\n* {field_key} must be a valid field in your documents, the value should be a json object with an (optional) `weight`\n  key/value (see below)\n\n`search_field.{field_key}.weight` (optional)\n* Weight is given between 10 (most relevant) to 1 (least relevant). You can also set weight to 0 to make the field\n  unsearchable at query time.\n\n`result_fields` (optional)\n* Change the fields which appear in search results and how their values are rendered\n* **Note:** `id` is a special case. It will always return within the `raw` object, and it ignores any requests for\n  `size` or `snippet`\n\n`result_fields.{field_key}` (optional)\n* {field_key} must be a valid field in your documents, the value should be a json object with an (optional) `raw`\n  and/or `snippet` keys (see below)\n\n`result_fields.{field_key}.raw` (optional)\n* An exact representation of the value within a field. And it is exact! It is not HTML escaped\n* A json object with an optional `size` key (see below).\n\n`result_fields.{field_key}.raw.size` (optional)\n* Length of the return value. Only can be used on text fields\n* Must be at least 20\n* Defaults to the entire text field\n* If given for a different field type other than text, it will be silently ignored.\n\n`result_fields.{field_key}.snippet` (optional)\n* The query match will be wrapped in `<em></em>` tags, for highlighting, if a match exists\n* A json object with optional `size` and `fallback` keys (see below)\n\n`result_fields.{field_key}.snippet.size` (optional)\n* Character length of the snippet returned\n* Must be at least 20\n* Defaults to 100.\n\n`result_fields.{field_key}.snippet.fallback` (optional)\n* If true, return the raw text field if no snippet is found. If false, only use snippets.\n\n`analytics` (optional)\n* Object to delimit the analytics parameters.\n\n`analytics.tags` **(required)**\n* Array of strings representing the tags you’d like to apply to the query\n* You may submit up to 16 tags, and each may be up to 64 characters in length.\n\n`record_analytics` (optional)\n* If `true`, generates an analytics query event for the search request\n* Defaults to `true`.","operationId":"search_post","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/SearchRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"anyOf":[{"$ref":"#/components/schemas/SearchResponse"},{"type":"null"}],"title":"Response Search Post"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/{engine_name}/settings":{"get":{"tags":["settings"],"summary":"Get Settings","operationId":"settings_get","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SettingsResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["settings"],"summary":"Post Settings","description":"**Body:**\n\n`precision` (optional)\n* Precision tuning setting for your engine\n* Valid options are 1 - 11 (inclusive)\n* 1: Highest recall (least precise)\n* 2: Default: Less than half of the terms have to match. Full typo tolerance is applied\n* 3: Increased term requirements: To match, documents must contain all terms for queries with up to 2 terms, then half if there are more. Full typo tolerance is applied\n* 4: Increased term requirements: To match, documents must contain all terms for queries with up to 3 terms, then three-quarters if there are more. Full typo tolerance is applied\n* 5: Increased term requirements: To match, documents must contain all terms for queries with up to 4 terms, then all but one if there are more. Full typo tolerance is applied\n* 6: Increased term requirements: To match, documents must contain all terms for any query. Full typo tolerance is applied\n* 7: Strictest term requirements: To match, documents must contain all terms in the same field. Full typo tolerance is applied\n* 8: Strictest term requirements: To match, documents must contain all terms in the same field. Partial typo tolerance is applied: fuzzy matching is disabled\n* 9: Strictest term requirements: To match, documents must contain all terms in the same field. Partial typo tolerance is applied: fuzzy matching and prefixing are disabled\n* 10: Strictest term requirements: To match, documents must contain all terms in the same field. Partial typo tolerance is applied: in addition to the above, contractions and hyphenations are not corrected\n* 11: Only exact matches will apply, with tolerance only for differences in capitalization (most precise)","operationId":"settings_post","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/SettingsRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SettingsResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/{engine_name}/spelling_suggestion":{"post":{"tags":["search"],"summary":"Post Spelling Suggestion","description":"Provide relevant spelling suggestions for queries. Not to be confused with autocomplete.\n\nOnly available on text fields.\n\n**Body:**\n\n`query` **(required)**\n* A query for which to receive spelling suggestions.\n\n`fields` **(required)**\n* Specify the fields within your documents that you would like spelling suggestions from. At least one field is\n  required.\n\n`size` (optional)\n* Number of spelling suggestions to return. Must be between 1 and 10. Defaults to 1.","operationId":"spelling_suggestion_post","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/SpellingSuggestionRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SpellingSuggestionResponse"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/{engine_name}/synonyms":{"get":{"tags":["synonyms"],"summary":"Get Rules","description":"Retrieve all synonyms for a particular engine.","operationId":"synonym_rules_get","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/SynonymRule"},"title":"Response Synonym Rules Get"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"post":{"tags":["synonyms"],"summary":"Post Rule","description":"The POST method will automatically generate an ID for your synonym.\n\nOur synonym format supports two styles of definition:\n\n* Equivalent synonyms: Groups of words, where any word in the group is a valid replacement. Example:\n    * \"ipod, i-pod, i pod\"\n    * \"computer, pc, laptop\"\n* Explicit synonyms: Groups of words that are replaced by a second group of words. IE words on the left are replaced\n  (and expanded) into the words on the right. Example:\n    * \"pc => personal computer\"\n    * \"js => javascript, es6\"\n    * \"sea biscuit, sea biscit => seabiscuit\"\n* A maximum of 32 words can be added to a synonym","operationId":"synonym_rule_post","security":[{"HTTPBearer":[]}],"parameters":[{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/SynonymRuleRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SynonymRule"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/{engine_name}/synonyms/{rule_id}":{"put":{"tags":["synonyms"],"summary":"Put Rule","description":"Create or update an existing synonym.\n\nOur synonym value format supports two styles of definition:\n\n* Equivalent synonyms: Groups of words, where any word in the group is a valid replacement. Example:\n    * \"ipod, i-pod, i pod\"\n    * \"computer, pc, laptop\"\n* Explicit synonyms: Groups of words that are replaced by a second group of words. IE words on the left are replaced\n  (and expanded) into the words on the right. Example:\n    * \"pc => personal computer\"\n    * \"js => javascript, es6\"\n    * \"sea biscuit, sea biscit => seabiscuit\"\n* A maximum of 32 words can be added to a synonym","operationId":"synonym_rule_put","security":[{"HTTPBearer":[]}],"parameters":[{"name":"rule_id","in":"path","required":true,"schema":{"type":"string","title":"Rule Id"}},{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/SynonymRuleRequest"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SynonymRule"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"get":{"tags":["synonyms"],"summary":"Get Rule","description":"Retrieve a specific synonym by its ID.","operationId":"synonym_rule_get","security":[{"HTTPBearer":[]}],"parameters":[{"name":"rule_id","in":"path","required":true,"schema":{"type":"string","title":"Rule Id"}},{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/SynonymRule"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["synonyms"],"summary":"Delete Rule","description":"Delete an existing synonym value by its ID.","operationId":"synonym_rule_delete","security":[{"HTTPBearer":[]}],"parameters":[{"name":"rule_id","in":"path","required":true,"schema":{"type":"string","title":"Rule Id"}},{"name":"engine_name","in":"path","required":true,"schema":{"type":"string","title":"Your engine name (as provided by Silverstripe)"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ResponseSuccess"}}}},"404":{"description":"Not found"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}}},"components":{"schemas":{"Coordinate":{"properties":{"latitude":{"anyOf":[{"type":"number","maximum":90.0,"minimum":-90.0},{"type":"string"}],"title":"Latitude"},"longitude":{"anyOf":[{"type":"number","maximum":180.0,"minimum":-180.0},{"type":"string"}],"title":"Longitude"}},"type":"object","required":["latitude","longitude"],"title":"Coordinate"},"Document":{"additionalProperties":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"items":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"}]},"type":"array"}]},"type":"object","title":"Document","examples":[{"acres":"147237.02","date_established":"1919-11-19T06:00:00Z","description":"Lorem ipsum.","id":"park_zion","location":"37.3,-113.05","nps_link":"https://www.nps.gov/zion/index.htm","square_km":"595.8","states":["Utah"],"title":"Zion","visitors":"4295127","world_heritage_site":"false"}]},"DocumentField":{"properties":{"raw":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"items":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"}]},"type":"array"},{"type":"null"}],"title":"Raw"},"snippet":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"items":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"}]},"type":"array"},{"type":"null"}],"title":"Snippet"}},"type":"object","title":"DocumentField"},"DocumentListRequest":{"properties":{"page":{"anyOf":[{"$ref":"#/components/schemas/PaginationNoTotals"},{"type":"null"}],"default":{"current":1,"size":10}}},"type":"object","title":"DocumentListRequest"},"DocumentListResponse":{"properties":{"meta":{"$ref":"#/components/schemas/DocumentListResponseMeta"},"results":{"items":{"$ref":"#/components/schemas/Document"},"type":"array","title":"Results"}},"type":"object","required":["meta","results"],"title":"DocumentListResponse"},"DocumentListResponseMeta":{"properties":{"alerts":{"anyOf":[{"items":{},"type":"array"},{"type":"null"}],"title":"Alerts"},"page":{"$ref":"#/components/schemas/PaginationWithTotals"},"request_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Request Id"},"warnings":{"anyOf":[{"items":{},"type":"array"},{"type":"null"}],"title":"Warnings"}},"type":"object","required":["page"],"title":"DocumentListResponseMeta"},"DocumentPostPatchResponse":{"properties":{"id":{"type":"string","title":"Id"},"errors":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Errors"}},"type":"object","required":["id"],"title":"DocumentPostPatchResponse","examples":[{"errors":[],"id":"park_zion"}]},"DocumentResponse":{"additionalProperties":{"oneOf":[{"$ref":"#/components/schemas/DocumentResponseMeta"},{"$ref":"#/components/schemas/DocumentField"}]},"type":"object","title":"DocumentResponse","examples":[{"_meta":{"engine":"search-parks-main","id":"park_everglades","score":1396363.1},"acres":{"raw":1508968.1},"date_established":{"raw":"1934-05-30T05:00:00+00:00"},"description":{"raw":"The Everglades are the largest tropical wilderness in the United States."},"id":{"raw":"park_everglades"},"location":{"raw":"25.32,-80.93"},"nps_link":{"raw":"https://www.nps.gov/ever/index.htm"},"square_km":{"raw":6106.6},"states":{"raw":["Florida"]},"title":{"raw":"Everglades"},"visitors":{"raw":930907},"world_heritage_site":{"raw":"true"}}]},"DocumentResponseMeta":{"properties":{"score":{"anyOf":[{"type":"number"},{"type":"null"}],"title":"Score"},"engine":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Engine"},"id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Id"}},"type":"object","title":"DocumentResponseMeta"},"DocumentsDeleteResponse":{"properties":{"id":{"type":"string","title":"Id","examples":["park_zion"]},"deleted":{"type":"boolean","title":"Deleted","examples":[true]}},"type":"object","required":["id","deleted"],"title":"DocumentsDeleteResponse"},"Engine":{"properties":{"name":{"type":"string","title":"Name","examples":["search-national-parks-demo"]}},"type":"object","required":["name"],"title":"Engine"},"EnginesResponse":{"properties":{"results":{"items":{"$ref":"#/components/schemas/Engine"},"type":"array","title":"Results"}},"type":"object","required":["results"],"title":"EnginesResponse"},"FacetResponse":{"properties":{"type":{"type":"string","enum":["value","range"],"title":"Type"},"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"data":{"items":{"oneOf":[{"$ref":"#/components/schemas/ResponseFacetValue"},{"$ref":"#/components/schemas/ResponseFacetRange"}]},"type":"array","title":"Data"}},"type":"object","required":["type","data"],"title":"FacetResponse"},"FacetsRequest":{"additionalProperties":{"items":{"oneOf":[{"$ref":"#/components/schemas/RequestFacetValue"},{"$ref":"#/components/schemas/RequestFacetRange"}]},"type":"array"},"type":"object","title":"FacetsRequest"},"FilterObjectLevel1":{"properties":{"all":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel2"}]},"type":"array"},{"type":"null"}],"title":"All"},"any":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel2"}]},"type":"array"},{"type":"null"}],"title":"Any"},"none":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel2"}]},"type":"array"},{"type":"null"}],"title":"None"}},"type":"object","title":"FilterObjectLevel1"},"FilterObjectLevel2":{"properties":{"all":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel3"}]},"type":"array"},{"type":"null"}],"title":"All"},"any":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel3"}]},"type":"array"},{"type":"null"}],"title":"Any"},"none":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel3"}]},"type":"array"},{"type":"null"}],"title":"None"}},"type":"object","title":"FilterObjectLevel2"},"FilterObjectLevel3":{"properties":{"all":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel4"}]},"type":"array"},{"type":"null"}],"title":"All"},"any":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel4"}]},"type":"array"},{"type":"null"}],"title":"Any"},"none":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel4"}]},"type":"array"},{"type":"null"}],"title":"None"}},"type":"object","title":"FilterObjectLevel3"},"FilterObjectLevel4":{"properties":{"all":{"anyOf":[{"items":{"$ref":"#/components/schemas/ValueFilter"},"type":"array"},{"type":"null"}],"title":"All"},"any":{"anyOf":[{"items":{"$ref":"#/components/schemas/ValueFilter"},"type":"array"},{"type":"null"}],"title":"Any"},"none":{"anyOf":[{"items":{"$ref":"#/components/schemas/ValueFilter"},"type":"array"},{"type":"null"}],"title":"None"}},"type":"object","title":"FilterObjectLevel4"},"Filters":{"properties":{"all":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel1"}]},"type":"array"},{"type":"null"}],"title":"All"},"any":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel1"}]},"type":"array"},{"type":"null"}],"title":"Any"},"none":{"anyOf":[{"items":{"oneOf":[{"$ref":"#/components/schemas/ValueFilter"},{"$ref":"#/components/schemas/FilterObjectLevel1"}]},"type":"array"},{"type":"null"}],"title":"None"}},"type":"object","title":"Filters","examples":[{"all":[{"date":{"from":"2018-07-02","to":"2018-07-02"}},{"states":"Washington"},{"states":["Washington","Idaho"]},{"location":{"center":{"latitude":-77.08,"longitude":38.89},"distance":2,"unit":"km"}}],"any":[{"date":{"from":"2018-07-02","to":"2018-07-02"}},{"states":"Washington"},{"states":["Washington","Idaho"]},{"location":{"center":{"latitude":-77.08,"longitude":38.89},"from":0,"to":1000,"unit":"km"}}],"none":[{"date":{"from":"2018-07-02","to":"2018-07-02"}},{"states":"Washington"},{"states":["Washington","Idaho"]}]}]},"Geo":{"properties":{"from":{"anyOf":[{"type":"integer"},{"type":"number"},{"type":"string"},{"type":"null"}],"title":"From"},"to":{"anyOf":[{"type":"integer"},{"type":"number"},{"type":"string"},{"type":"null"}],"title":"To"},"center":{"anyOf":[{"$ref":"#/components/schemas/Coordinate"},{"prefixItems":[{"anyOf":[{"type":"number"},{"type":"string"}]},{"anyOf":[{"type":"number"},{"type":"string"}]}],"type":"array","maxItems":2,"minItems":2},{"type":"string"}],"title":"Center"},"unit":{"$ref":"#/components/schemas/Unit"},"distance":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Distance"}},"type":"object","required":["center","unit"],"title":"Geo"},"Geolocation":{"properties":{"center":{"anyOf":[{"$ref":"#/components/schemas/Coordinate"},{"prefixItems":[{"anyOf":[{"type":"number"},{"type":"string"}]},{"anyOf":[{"type":"number"},{"type":"string"}]}],"type":"array","maxItems":2,"minItems":2},{"type":"string"}],"title":"Center"},"order":{"type":"string","enum":["asc","desc"],"title":"Order"}},"type":"object","required":["center","order"],"title":"Geolocation"},"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"PaginationNoTotals":{"properties":{"current":{"type":"integer","title":"","description":"Page number of results to return. Must be greater than or equal to 1 and less than or equal to \n        100. Defaults to 1.","default":1,"examples":[1]},"size":{"type":"integer","title":"","description":"Number of results per page. Must be greater than or equal to 1 and less than or equal to 1000. \n        Defaults to 10.","default":10,"examples":[5]}},"type":"object","title":"PaginationNoTotals"},"PaginationWithTotals":{"properties":{"current":{"type":"integer","title":"Current","description":"Number representing the current page of results.","examples":[1]},"size":{"type":"integer","title":"Size","description":"Number representing the results per page.","examples":[5]},"total_pages":{"type":"integer","title":"Total Pages","description":"Number representing the total pages of results.\n        Value is 0 when you paginate beyond 10,000 results.","examples":[5]},"total_results":{"type":"integer","title":"Total Results","description":"Number representing the total results across all pages.\n        The values 0 through 9999 are exact counts.\n        The value 10000 is a pseudo keyword representing greater than or equal to 10,000 results.","examples":[22]}},"type":"object","required":["current","size","total_pages","total_results"],"title":"PaginationWithTotals"},"QuerySuggestionRequest":{"properties":{"query":{"type":"string","title":"Query","description":"A partial query for which to receive suggestions.","examples":["car"]},"size":{"type":"integer","maximum":20.0,"minimum":1.0,"title":"Size","description":"Maximum number of query suggestions to return. Must be between 1 and 20. Defaults to 10.","default":10,"examples":[4]},"fields":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Fields","description":"Specify the document fields to look for suggestions within. Defaults to all text fields.","examples":[["title","content"]]}},"type":"object","required":["query"],"title":"QuerySuggestionRequest"},"QuerySuggestionResponse":{"properties":{"results":{"items":{"$ref":"#/components/schemas/QuerySuggestionResponseValue"},"type":"array","title":"Results"}},"type":"object","required":["results"],"title":"QuerySuggestionResponse","examples":[{"results":[{"raw":"carl's"},{"raw":"carl's caverns"},{"raw":"carolina"}]}]},"QuerySuggestionResponseValue":{"properties":{"raw":{"type":"string","title":"Raw"}},"type":"object","required":["raw"],"title":"QuerySuggestionResponseValue"},"Range":{"properties":{"from":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"type":"null"}],"title":"From"},"to":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"type":"null"}],"title":"To"}},"type":"object","title":"Range"},"RequestFacetRange":{"properties":{"type":{"type":"string","enum":["value","range"],"title":"Type"},"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"ranges":{"items":{"$ref":"#/components/schemas/RequestFacetRangeObject"},"type":"array","title":"Ranges"}},"type":"object","required":["type","ranges"],"title":"RequestFacetRange"},"RequestFacetRangeObject":{"properties":{"from":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"type":"null"}],"title":"From"},"to":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"type":"null"}],"title":"To"},"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"}},"type":"object","title":"RequestFacetRangeObject"},"RequestFacetValue":{"properties":{"type":{"type":"string","enum":["value","range"],"title":"Type"},"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"size":{"type":"integer","maximum":100.0,"minimum":1.0,"title":"Size","default":10},"sort":{"anyOf":[{"$ref":"#/components/schemas/RequestFacetValueSort"},{"type":"null"}]}},"type":"object","required":["type"],"title":"RequestFacetValue"},"RequestFacetValueSort":{"additionalProperties":{"type":"string","enum":["asc","desc"]},"propertyNames":{"enum":["count","value"]},"type":"object","title":"RequestFacetValueSort"},"ResponseFacetRange":{"properties":{"from":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"type":"null"}],"title":"From"},"to":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"},{"type":"null"}],"title":"To"},"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"count":{"type":"integer","title":"Count"}},"type":"object","required":["count"],"title":"ResponseFacetRange"},"ResponseFacetValue":{"properties":{"value":{"anyOf":[{"type":"string"},{"type":"integer"},{"type":"number"}],"title":"Value"},"count":{"type":"integer","title":"Count"}},"type":"object","required":["value","count"],"title":"ResponseFacetValue"},"ResponseSuccess":{"properties":{"success":{"type":"boolean","title":"Success","examples":[true]}},"type":"object","required":["success"],"title":"ResponseSuccess"},"Schema":{"properties":{"_attachment":{"anyOf":[{"type":"string","const":"binary"},{"type":"null"}],"title":"Attachment"},"body":{"anyOf":[{"type":"string","const":"text"},{"type":"null"}],"title":"Body"}},"additionalProperties":{"$ref":"#/components/schemas/ValidFields"},"type":"object","title":"Schema"},"SchemaPostResponse":{"properties":{"acknowledged":{"type":"boolean","title":"Acknowledged","examples":[true]}},"type":"object","required":["acknowledged"],"title":"SchemaPostResponse"},"SearchRequest":{"properties":{"query":{"type":"string","title":"Query","examples":["lorem"]},"sort":{"anyOf":[{"$ref":"#/components/schemas/Sort"},{"type":"null"}]},"page":{"anyOf":[{"$ref":"#/components/schemas/PaginationNoTotals"},{"type":"null"}]},"search_fields":{"anyOf":[{"$ref":"#/components/schemas/SearchRequestSearchFields"},{"type":"null"}]},"result_fields":{"anyOf":[{"$ref":"#/components/schemas/SearchRequestResultFields"},{"type":"null"}]},"facets":{"anyOf":[{"$ref":"#/components/schemas/FacetsRequest"},{"type":"null"}]},"filters":{"anyOf":[{"$ref":"#/components/schemas/Filters"},{"type":"null"}]},"analytics":{"anyOf":[{"$ref":"#/components/schemas/Tags"},{"type":"null"}]}},"type":"object","required":["query"],"title":"SearchRequest"},"SearchRequestResultField":{"properties":{"raw":{"anyOf":[{"$ref":"#/components/schemas/SearchRequestResultFieldRaw"},{"type":"null"}]},"snippet":{"anyOf":[{"$ref":"#/components/schemas/SearchRequestResultFieldSnippet"},{"type":"null"}],"description":"If given for a field type other than text, it will be silently ignored."}},"type":"object","title":"SearchRequestResultField"},"SearchRequestResultFieldRaw":{"properties":{"size":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Size","description":"Length of the return value (to the nearest word). Can only be used on text fields. If given for \n        a field type other than text, it will be silently ignored. Defaults to the entire text field."}},"type":"object","title":"SearchRequestResultFieldRaw"},"SearchRequestResultFieldSnippet":{"properties":{"size":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Size","description":"Character length of the snippet returned (to the nearest word). Must be at least 20; defaults to \n        100.","default":100},"fallback":{"anyOf":[{"type":"boolean"},{"type":"null"}],"title":"Fallback","description":"If true, return the raw text field as the snippet (if no snippet is found). Defaults to true.","default":true}},"type":"object","title":"SearchRequestResultFieldSnippet"},"SearchRequestResultFields":{"additionalProperties":{"$ref":"#/components/schemas/SearchRequestResultField"},"type":"object","title":"SearchRequestResultFields","examples":[{"description":{"raw":{"size":200},"snippet":{"size":100}},"states":{"raw":{},"snippet":{"fallback":false,"size":20}},"title":{"snippet":{"fallback":true,"size":20}}}]},"SearchRequestSearchFields":{"anyOf":[{"additionalProperties":{"$ref":"#/components/schemas/SearchRequestSearchFieldsWeight"},"type":"object"},{"type":"null"}],"title":"SearchRequestSearchFields","examples":[{"description":{"weight":5},"states":{"weight":3},"title":{"weight":10}}]},"SearchRequestSearchFieldsWeight":{"properties":{"weight":{"anyOf":[{"type":"integer"},{"type":"number"},{"type":"null"}],"title":"Weight"}},"type":"object","title":"SearchRequestSearchFieldsWeight"},"SearchResponse":{"properties":{"meta":{"$ref":"#/components/schemas/SearchResponseMeta"},"results":{"items":{"$ref":"#/components/schemas/DocumentResponse"},"type":"array","title":"Results"},"facets":{"anyOf":[{"additionalProperties":{"items":{"$ref":"#/components/schemas/FacetResponse"},"type":"array"},"type":"object"},{"type":"null"}],"title":"Facets"}},"type":"object","required":["meta","results"],"title":"SearchResponse"},"SearchResponseEngine":{"properties":{"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"type":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Type"}},"type":"object","title":"SearchResponseEngine"},"SearchResponseMeta":{"properties":{"warnings":{"anyOf":[{"items":{"type":"string"},"type":"array"},{"type":"null"}],"title":"Warnings","default":[]},"precision":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Precision"},"engine":{"anyOf":[{"$ref":"#/components/schemas/SearchResponseEngine"},{"type":"null"}]},"request_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Request Id"},"page":{"$ref":"#/components/schemas/PaginationWithTotals"}},"type":"object","required":["page"],"title":"SearchResponseMeta"},"SettingsRequest":{"properties":{"precision":{"type":"integer","maximum":11.0,"minimum":1.0,"title":"Precision","description":"Precision setting for your engine. Valid values are 1 - 11 (inclusive)","examples":[2]}},"type":"object","required":["precision"],"title":"SettingsRequest"},"SettingsResponse":{"properties":{"precision":{"type":"integer","title":"Precision"}},"type":"object","required":["precision"],"title":"SettingsResponse"},"Sort":{"anyOf":[{"items":{"additionalProperties":{"oneOf":[{"type":"string","enum":["asc","desc"]},{"$ref":"#/components/schemas/Geolocation"}]},"type":"object"},"type":"array"},{"type":"null"}],"title":"Sort","examples":[[{"_score":"desc"},{"title":"desc"},{"location":{"center":{"latitude":-77.08,"longitude":38.89},"order":"asc"}}]]},"SpellingSuggestionRequest":{"properties":{"query":{"type":"string","title":"Query","description":"A query for which to receive spelling suggestions.","examples":["caros"]},"size":{"type":"integer","maximum":10.0,"minimum":1.0,"title":"Size","description":"Maximum number of spelling suggestions to return. Must be between 1 and 10. Defaults to 1.","default":1,"examples":[4]},"fields":{"$ref":"#/components/schemas/ValidatedFields","description":"Specify the document fields to look for suggestions within. At least 1 field is required.","examples":[["title","content"]]},"formatted":{"anyOf":[{"type":"boolean"},{"type":"null"}],"title":"Formatted","description":"Whether you would like a 'snippet' field to be returned with each of your results.","default":false,"examples":[true]}},"type":"object","required":["query","fields"],"title":"SpellingSuggestionRequest"},"SpellingSuggestionResponse":{"properties":{"results":{"items":{"$ref":"#/components/schemas/DocumentField"},"type":"array","title":"Results"}},"type":"object","required":["results"],"title":"SpellingSuggestionResponse","examples":[{"results":[{"raw":"carl's","snippet":"<em>carl's</em>"},{"raw":"carolina","snippet":"<em>carolina</em>"}]}]},"SynonymRule":{"properties":{"id":{"type":"string","title":"Id"},"synonyms":{"type":"string","title":"Synonyms"}},"type":"object","required":["id","synonyms"],"title":"SynonymRule"},"SynonymRuleRequest":{"properties":{"synonyms":{"type":"string","title":"Synonyms"}},"type":"object","required":["synonyms"],"title":"SynonymRuleRequest"},"Tags":{"properties":{"tags":{"items":{"type":"string"},"type":"array","title":"Tags","description":"The Search endpoint can be used to attach tags to your documents. One or more tags can be applied \n        to filter results via the API or within your analytics dashboard.","examples":[["desktop","mobile"]]}},"type":"object","required":["tags"],"title":"Tags"},"Unit":{"type":"string","enum":["mm","cm","m","km","in","ft","yd","mi"],"title":"Unit"},"ValidFields":{"type":"string","enum":["text","date","geolocation","number","binary"],"title":"ValidFields"},"ValidatedFields":{"items":{"type":"string"},"type":"array","title":"ValidatedFields"},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"},"ValueFilter":{"additionalProperties":{"oneOf":[{"$ref":"#/components/schemas/Range"},{"$ref":"#/components/schemas/Geo"},{"anyOf":[{"type":"string"},{"type":"boolean"},{"type":"integer"},{"type":"number"}]},{"items":{"anyOf":[{"type":"string"},{"type":"boolean"},{"type":"integer"},{"type":"number"}]},"type":"array"}]},"type":"object","title":"ValueFilter"}},"securitySchemes":{"HTTPBearer":{"type":"http","scheme":"bearer"}}}}
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Bifröst",
+        "description": "\nBifröst API 🌈\n\nManaged search for Silverstripe Cloud\n",
+        "termsOfService": "https://silverstripe.com/search#terms",
+        "contact": {
+            "name": "Silverstripe Ltd",
+            "url": "https://silverstripe.com/search"
+        },
+        "version": "1.4.0"
+    },
+    "servers": [
+        {
+            "url": "/api/v1"
+        }
+    ],
+    "paths": {
+        "/{engine_name}/field/{field_name}/boosts": {
+            "get": {
+                "tags": [
+                    "boosts"
+                ],
+                "summary": "Get Boosts",
+                "description": "Get all boosts for a field.",
+                "operationId": "boosts_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "field_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "Name of the field to get boosts for",
+                            "title": "Field Name"
+                        },
+                        "description": "Name of the field to get boosts for"
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/BoostGetResponse"
+                                    },
+                                    "title": "Response Boosts Get"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "boosts"
+                ],
+                "summary": "Post Boost",
+                "description": "Create a new boost for a field.",
+                "operationId": "boosts_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "field_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "Name of the field to add boost to",
+                            "title": "Field Name"
+                        },
+                        "description": "Name of the field to add boost to"
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BoostPostRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BoostPostResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/field/{field_name}/boosts/{boost_id}": {
+            "get": {
+                "tags": [
+                    "boosts"
+                ],
+                "summary": "Get Boost",
+                "description": "Get a specific boost by its ID.",
+                "operationId": "boost_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "field_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "Name of the field",
+                            "title": "Field Name"
+                        },
+                        "description": "Name of the field"
+                    },
+                    {
+                        "name": "boost_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "ID of the boost to retrieve",
+                            "title": "Boost Id"
+                        },
+                        "description": "ID of the boost to retrieve"
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BoostGetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "boosts"
+                ],
+                "summary": "Patch Boost",
+                "description": "Update a specific boost by its ID.",
+                "operationId": "boost_patch",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "field_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "Name of the field",
+                            "title": "Field Name"
+                        },
+                        "description": "Name of the field"
+                    },
+                    {
+                        "name": "boost_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "ID of the boost to update",
+                            "title": "Boost Id"
+                        },
+                        "description": "ID of the boost to update"
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BoostPatchRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BoostGetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "boosts"
+                ],
+                "summary": "Delete Boost",
+                "description": "Delete a specific boost by its ID.",
+                "operationId": "boost_delete",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "field_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "Name of the field",
+                            "title": "Field Name"
+                        },
+                        "description": "Name of the field"
+                    },
+                    {
+                        "name": "boost_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "ID of the boost to delete",
+                            "title": "Boost Id"
+                        },
+                        "description": "ID of the boost to delete"
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseSuccess"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/click": {
+            "post": {
+                "tags": [
+                    "analytics"
+                ],
+                "summary": "Post Click",
+                "description": "Record a click event against a search result.\n\n**Body:**\n\n`request_id` **(required)**\n* The `request_id` returned in the `meta` of a search response.\n\n`document_id` **(required)**\n* The ID of the document that was clicked.",
+                "operationId": "click_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ClickRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseSuccess"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/curations": {
+            "post": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Post Curations",
+                "description": "Create a new curation for an engine.\n\n* `name`: An optional name for the curation. Can be useful in helping you easily identify the curation\n* `queries`: An optional list of query strings to be added to the curation at the time of creation",
+                "operationId": "curations_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/common__models__curation__post_request__PostRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Get Curations",
+                "description": "Retrieve all curations for an engine.",
+                "operationId": "curations_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/common__models__curation__get_response__GetResponse"
+                                    },
+                                    "title": "Response Curations Get"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/curations/{curation_id}": {
+            "get": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Get Curation",
+                "description": "Retrieve a specific curations for an engine.",
+                "operationId": "curation_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/common__models__curation__get_response__GetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Patch Curation",
+                "description": "Update a curation's details. Only provided fields are updated.\n\n* `name`: An optional name for the curation",
+                "operationId": "curation_patch",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/common__models__curation__patch_request__PatchRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/common__models__curation__get_response__GetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Delete Curation",
+                "description": "Delete a curation and all its related queries and documents.",
+                "operationId": "curation_delete",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseSuccess"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/curations/{curation_id}/documents": {
+            "post": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Post Curation Document",
+                "description": "Add a document to a curation.\n\nThe 'type' field determines how the document is curated:\n- 0 (HIDDEN): Document is hidden from search results for this curation\n- 1 (PROMOTED): Document is promoted in search results for this curation\n\nA maximum of 20 Documents can be added for each Curation Type (HIDDEN, PROMOTED).",
+                "operationId": "curation_documents_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/common__models__curation_document__post_request__PostRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/common__models__curation_document__get_response__GetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Get Curation Documents",
+                "description": "Retrieve all documents for a curation.",
+                "operationId": "curation_documents_get_all",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/common__models__curation_document__get_response__GetResponse"
+                                    },
+                                    "title": "Response Curation Documents Get All"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/curations/{curation_id}/documents/{document_id}": {
+            "get": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Get Curation Document",
+                "description": "Retrieve a specific document for a curation.",
+                "operationId": "curation_documents_get_one",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "document_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Document Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/common__models__curation_document__get_response__GetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Delete Curation Document",
+                "description": "Remove a document from a curation.",
+                "operationId": "curation_documents_delete",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "document_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Document Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseSuccess"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Patch Curation Document",
+                "description": "Update a document in a curation.\n\nOnly the fields provided in the request will be updated:\n- type: 0 (HIDDEN) or 1 (PROMOTED)\n- sort: The sort order for the document",
+                "operationId": "curation_documents_patch",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "document_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Document Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/common__models__curation_document__patch_request__PatchRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/common__models__curation_document__get_response__GetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/curations/{curation_id}/queries": {
+            "post": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Post Curation Query",
+                "description": "Create a new query for an existing curation.",
+                "operationId": "curation_queries_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/common__models__curation_query__post_request__PostRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PostResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Get Curation Queries",
+                "description": "Retrieve all queries for a curation.",
+                "operationId": "curation_queries_get_all",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/common__models__curation_query__get_response__GetResponse"
+                                    },
+                                    "title": "Response Curation Queries Get All"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/curations/{curation_id}/queries/{query_id}": {
+            "get": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Get Curation Query",
+                "description": "Retrieve a specific query for a curation.",
+                "operationId": "curation_queries_get_one",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "query_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Query Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/common__models__curation_query__get_response__GetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "curations"
+                ],
+                "summary": "Delete Curation Query",
+                "description": "Delete a query from a curation.",
+                "operationId": "curation_queries_delete",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "curation_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Curation Id"
+                        }
+                    },
+                    {
+                        "name": "query_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Query Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseSuccess"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/documents": {
+            "post": {
+                "tags": [
+                    "documents"
+                ],
+                "summary": "Post Documents",
+                "description": "Create or update documents.\n\nDocuments are indexed asynchronously. There will be a processing delay before they are available to your Engine.\n\n**Key points to remember when creating documents:**\n\n* It is recommended that you provide your own `id` field, but If no `id` is provided, a unique `id` will be\n  generated.\n* A new document is created each time content is received without an `id` - beware duplicates!\n* A document will be updated - not created - if its `id` already exists within a document.\n\n**Processing file contents**\n\n* An `_attachment` field can be used to attach PDF and Docx files to your document.\n* The _attachment` field should contain a base 64 encoded string of binary.",
+                "operationId": "documents_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "array",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "integer"
+                                                        },
+                                                        {
+                                                            "type": "number"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "examples": [
+                                        {
+                                            "id": "silverstripe_cms_model_sitetree_1",
+                                            "title": "Auckland Zoo",
+                                            "term_ids": [
+                                                1,
+                                                2,
+                                                5
+                                            ],
+                                            "location": "-36.8639680119916, 174.7199894180399",
+                                            "last_edited": "2024-06-14T13:53:44+12:00"
+                                        }
+                                    ]
+                                },
+                                "title": "Documents"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/DocumentPostPatchResponse"
+                                    },
+                                    "title": "Response Documents Post"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "documents"
+                ],
+                "summary": "Patch Documents",
+                "description": "Update specific document fields by `id` and `field`.\n\nThere are a couple of limitations of the PATCH action:\n- The `id` is required and new fields cannot be created using `PATCH`!\n- processing file content is **not supported** via PATCH",
+                "operationId": "documents_patch",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "array",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "integer"
+                                                        },
+                                                        {
+                                                            "type": "number"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "examples": [
+                                        {
+                                            "id": "silverstripe_cms_model_sitetree_1",
+                                            "title": "Auckland Zoo",
+                                            "term_ids": [
+                                                1,
+                                                2,
+                                                5
+                                            ],
+                                            "location": "-36.8639680119916, 174.7199894180399",
+                                            "last_edited": "2024-06-14T13:53:44+12:00"
+                                        }
+                                    ]
+                                },
+                                "title": "Documents"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/DocumentPostPatchResponse"
+                                    },
+                                    "title": "Response Documents Patch"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "documents"
+                ],
+                "summary": "Delete Documents",
+                "description": "Delete documents by `id`.",
+                "operationId": "documents_delete",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "examples": [
+                                    [
+                                        "park_zion",
+                                        "park_yosemite",
+                                        "does_not_exist"
+                                    ]
+                                ],
+                                "title": "Document Ids"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/DocumentsDeleteResponse"
+                                    },
+                                    "title": "Response Documents Delete"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "documents"
+                ],
+                "summary": "Get Documents",
+                "description": "A paginated array of JSON objects representing documents.\n\n**Query parameters:**\n\n`ids` **(required)**\n* A parameterized query of document `id`. EG: ids=zion_park&ids=does_not_exist",
+                "operationId": "documents_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "examples": [
+                                    [
+                                        "park_zion",
+                                        "park_yosemite",
+                                        "does_not_exist"
+                                    ]
+                                ],
+                                "title": "Document Ids"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Document"
+                                    },
+                                    "title": "Response Documents Get"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/documents/list": {
+            "post": {
+                "tags": [
+                    "documents"
+                ],
+                "summary": "Post Documents List",
+                "description": "**Body:**\n\n`page` (optional)\n* Object to delimit the pagination parameters\n\n`page.size` (optional)\n* Number of results per page\n* Must be greater than or equal to 1 and less than or equal to 100\n* Defaults to 10\n\n`page.current` (optional)\n* Page number of results to return\n* Must be greater than or equal to 1\n* Defaults to 1",
+                "operationId": "documents_list_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/DocumentListRequest"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "default": {
+                                    "page": {
+                                        "current": 1,
+                                        "size": 10
+                                    }
+                                },
+                                "title": "Body"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DocumentListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/engines": {
+            "post": {
+                "tags": [
+                    "engines"
+                ],
+                "summary": "Post Engines",
+                "operationId": "engines_post",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EnginesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ]
+            }
+        },
+        "/{engine_name}/query_suggestion": {
+            "post": {
+                "tags": [
+                    "search"
+                ],
+                "summary": "Post Query Suggestion",
+                "description": "Provide relevant query suggestions for incomplete queries. Also known as Autocomplete.\n\nOnly available on text fields.\n\n**Body:**\n\n`query` **(required)**\n* A partial query for which to receive suggestions.\n\n`types` (optional)\n* Specify the documents key within the types parameter to look for suggestions within certain text fields. Defaults to all text fields.\n\n`size` (optional)\n* Number of query suggestions to return. Must be between 1 and 20. Defaults to 10.",
+                "operationId": "query_suggestion_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/QuerySuggestionRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/QuerySuggestionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/schema": {
+            "get": {
+                "tags": [
+                    "configuration"
+                ],
+                "summary": "Get Schema",
+                "operationId": "schema_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SchemaGetResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "configuration"
+                ],
+                "summary": "Post Schema",
+                "description": "**Field types:**\n\n* `text`\n* `number`\n* `date`\n    * Strings containing formatted dates, e.g. \"2015-01-01\" or \"2015/01/01 12:10:30\".\n    * A number representing seconds-since-the-epoch.\n* `geolocation`\n\n**Field names:**\n\n* Must contain a lowercase letter and may only contain lowercase letters, numbers, and underscores.\n* Must not contain whitespace or have a leading underscore.\n* Must not contain more than 64 characters.\n* Must not be any of the following reserved words:\n    * `id`\n    * `engine_id`\n    * `search_index_id`\n    * `highlight`\n    * `any`\n    * `all`\n    * `none`\n    * `or`\n    * `and`\n    * `not`\n* The following fields can be used, but must be of type `text`\n    * `body`\n* The following fields can be used, but must be of type `binary`\n    * `_attachment`",
+                "operationId": "schema_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Schema"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseAcknowledged"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "configuration"
+                ],
+                "summary": "Delete Schema",
+                "description": "Deletes all schema fields for the engine, resetting it to an empty schema and engine.\n\n**Important:** Deleting the schema will also result in all Documents within the engine being deleted.",
+                "operationId": "schema_delete",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Token"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ResponseAcknowledged"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ResponseConfirm"
+                                        }
+                                    ],
+                                    "title": "Response Schema Delete"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/search": {
+            "post": {
+                "tags": [
+                    "search"
+                ],
+                "summary": "Post Search",
+                "description": "Submit a search and receive a set of results with metadata.\n\n**Body:**\n\n`query` **(required)**\n* String or number to match\n* The value '' (empty string) matches all documents\n* maximum length of 128 characters\n* The following Lucene query syntax is supported:\n    * double-quoted strings\n    * `+` and `-`\n    * `AND` and `NOT`\n\n`page` (optional)\n* Object to delimit the pagination parameters.\n\n`page.size` (optional)\n* Number of results per page\n* Must be greater than or equal to 1 and less than or equal to 1000\n* Defaults to 10.\n\n`page.current` (optional)\n* Page number of results to return\n* Must be greater than or equal to 1 and less than or equal to 100\n* Defaults to 1.\n\n`sort` (optional)\n* Sort your results in an order other than document score\n* JSON object where the key is the field you wish to sort on, and the value is `asc` or `desc`\n* Multiple keys/value pairs can be provided if you wish to sort against multiple fields\n* The following sorting options are available based on field type:\n    * `text`: Alphanumerically, case-sensitive\n    * `number`: Numerically\n    * `date`: Historically\n    * `geolocation`: By distance to a provided geographical point.\n\n`facets` (optional)\n* Create value and range facets\n* The facets key opens up the object where you define your facet field\n* The following facet types are available based on field type:\n    * `text`: Value facet\n    * `number`: Value facet, Range facet\n    * `date`: Value facet, Range facet\n    * `geolocation`: Currently unsupported\n\n`facets.{field_key}` **(required)**\n* The field from your schema upon which to apply your facet\n* Must contain an array of {facet_object}.\n\n`{facet_object}.type` **(required)**\n* Type of facet, one of either \"value\" or \"range\".\n\n`{facet_object}.name` (optional)\n* Name given to facet.\n\nValue facet:\n\n`{facet_object}.size` (optional)\n* How many facets would you like to return?\n* Can be between 1 and 100\n* Defaults to 10.\n\n`{facet_object}.sort` (optional)\n* JSON object where the key is either `count` or `value` and the value is `asc` or `desc`.\n* Defaults to descending `count`.\n\nRange facet:\n\n`{facet_object}.ranges` **(required)**\n* An array of {facet_range_object}.\n\n`{facet_range_object}.name` (optional)\n* A name given to the range.\n\n`{facet_range_object}.from` (optional)\n* Inclusive lower bound of the range. Is required if to is not given.\n\n`{facet_range_object}.to` (optional)\n* Exclusive upper bound of the range. Is required if from is not given.\n\n`filters` (optional)\n* Apply conditions to field values to filter results\n* The following filters are available based on field type:\n    * `text`: Value filter\n    * `number`: Value filter, Range filter\n    * `date`: Value filter, Range filter\n    * `geolocation`: Geo filter\n\n`boosts` (optional)\n* Apply boosts to influence the relevance scoring of results at query time\n* JSON object where the key is a field name and the value is an array of boost objects\n* Query-time boosts completely replace any stored boosts configured for the engine\n* The following boost types are available based on field type:\n    * `text`: Value boost\n    * `number`: Value boost, Proximity boost\n    * `date`: Value boost, Proximity boost (recency)\n    * `geolocation`: Proximity boost\n\n`boosts.{field_key}` **(required)**\n* The field from your schema upon which to apply your boost\n* Must contain an array of {boost_object}.\n\n`{boost_object}.type` **(required)**\n* Type of boost: \"value\" or \"proximity\"\n\n`{boost_object}.value` **(required for value boosts)**\n* An array of string values to match against\n* Documents with matching values in the boosted field will have their relevance score increased.\n\n`{boost_object}.center` **(required for proximity boosts)**\n* The center point from which to calculate distance\n* For date fields: a date string (e.g. \"2024-01-01\") or a relative date expression.\n  Supported formats: \"now\", \"now-1d\", \"now-7d\", \"now-1M\", \"now-1y\", \"now/d\" (rounded to start of day)\n* For number fields: a numeric string (e.g. \"100\")\n* For geolocation fields: a lat,lon string (e.g. \"-36.8485,174.7633\")\n\n`{boost_object}.function` **(required for proximity boosts)**\n* The decay function to use: \"gaussian\", \"exponential\", or \"linear\"\n* Gaussian provides a smooth bell-curve decay\n* Exponential provides a sharp initial decay that flattens over distance\n* Linear provides a constant rate of decay\n\n`{boost_object}.factor` (optional)\n* The strength of the boost, between 0 and 10\n* Defaults to 1.\n\n`search_fields` (optional)\n* The search_fields parameter restricts a query to search only specific fields\n* Restricting fields will result in faster queries, especially for schemas with many text fields\n* Only available within text fields.\n\n`search_field.{field_key}` **(required)**\n* {field_key} must be a valid field in your documents, the value should be a json object with an (optional) `weight`\n  key/value (see below)\n\n`search_field.{field_key}.weight` (optional)\n* Weight is given between 10 (most relevant) to 1 (least relevant). You can also set weight to 0 to make the field\n  unsearchable at query time.\n\n`result_fields` (optional)\n* Change the fields which appear in search results and how their values are rendered\n* **Note:** `id` is a special case. It will always return within the `raw` object, and it ignores any requests for\n  `size` or `snippet`\n\n`result_fields.{field_key}` (optional)\n* {field_key} must be a valid field in your documents, the value should be a json object with an (optional) `raw`\n  and/or `snippet` keys (see below)\n\n`result_fields.{field_key}.raw` (optional)\n* An exact representation of the value within a field. And it is exact! It is not HTML escaped\n* A json object with an optional `size` key (see below).\n\n`result_fields.{field_key}.raw.size` (optional)\n* Length of the return value. Only can be used on text fields\n* Must be at least 20\n* Defaults to the entire text field\n* If given for a different field type other than text, it will be silently ignored.\n\n`result_fields.{field_key}.snippet` (optional)\n* The query match will be wrapped in `<em></em>` tags, for highlighting, if a match exists\n* A json object with optional `size` and `fallback` keys (see below)\n\n`result_fields.{field_key}.snippet.size` (optional)\n* Character length of the snippet returned\n* Must be at least 20\n* Defaults to 100.\n\n`result_fields.{field_key}.snippet.fallback` (optional)\n* If true, return the raw text field if no snippet is found. If false, only use snippets.\n\n`analytics` (optional)\n* Object to delimit the analytics parameters.\n* Only available to Analyst and Architect plans.\n\n`analytics.tags` **(required)**\n* Array of strings representing the tags you’d like to apply to the query\n* You may submit up to 16 tags, and each may be up to 64 characters in length.\n* Only available to Analyst and Architect plans.\n\n`record_analytics` (optional)\n* If `true`, generates an analytics query event for the search request\n* Defaults to `true`.\n* Only available to Analyst and Architect plans.",
+                "operationId": "search_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SearchRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SearchResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/settings": {
+            "get": {
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Get Settings",
+                "operationId": "settings_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SettingsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Post Settings",
+                "description": "**Body:**\n\n`precision` (optional)\n* Precision tuning setting for your engine\n* Valid options are 1 - 11 (inclusive)\n* 1: Highest recall (least precise)\n* 2: Default: Less than half of the terms have to match. Full typo tolerance is applied\n* 3: Increased term requirements: To match, documents must contain all terms for queries with up to 2 terms, then half if there are more. Full typo tolerance is applied\n* 4: Increased term requirements: To match, documents must contain all terms for queries with up to 3 terms, then three-quarters if there are more. Full typo tolerance is applied\n* 5: Increased term requirements: To match, documents must contain all terms for queries with up to 4 terms, then all but one if there are more. Full typo tolerance is applied\n* 6: Increased term requirements: To match, documents must contain all terms for any query. Full typo tolerance is applied\n* 7: Strictest term requirements: To match, documents must contain all terms in the same field. Full typo tolerance is applied\n* 8: Strictest term requirements: To match, documents must contain all terms in the same field. Partial typo tolerance is applied: fuzzy matching is disabled\n* 9: Strictest term requirements: To match, documents must contain all terms in the same field. Partial typo tolerance is applied: fuzzy matching and prefixing are disabled\n* 10: Strictest term requirements: To match, documents must contain all terms in the same field. Partial typo tolerance is applied: in addition to the above, contractions and hyphenations are not corrected\n* 11: Only exact matches will apply, with tolerance only for differences in capitalization (most precise)",
+                "operationId": "settings_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SettingsRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SettingsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/spelling_suggestion": {
+            "post": {
+                "tags": [
+                    "search"
+                ],
+                "summary": "Post Spelling Suggestion",
+                "description": "Provide relevant spelling suggestions for queries. Not to be confused with autocomplete.\n\nOnly available on text fields.\n\n**Body:**\n\n`query` **(required)**\n* A query for which to receive spelling suggestions.\n\n`fields` **(required)**\n* Specify the fields within your documents that you would like spelling suggestions from. At least one field is\n  required.\n\n`size` (optional)\n* Number of spelling suggestions to return. Must be between 1 and 10. Defaults to 1.",
+                "operationId": "spelling_suggestion_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SpellingSuggestionRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SpellingSuggestionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/synonyms": {
+            "get": {
+                "tags": [
+                    "synonyms"
+                ],
+                "summary": "Get Synonym Rules",
+                "description": "Retrieve all synonyms for a particular engine.",
+                "operationId": "synonym_rules_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SynonymRule"
+                                    },
+                                    "title": "Response Synonym Rules Get"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "synonyms"
+                ],
+                "summary": "Post Synonym Rule",
+                "description": "The POST method will automatically generate an ID for your synonym.\n\nOur synonym format supports two styles of definition:\n\n* Equivalent synonyms: Groups of words, where any word in the group is a valid replacement. Example:\n    * \"ipod, i-pod, i pod\"\n    * \"computer, pc, laptop\"\n* Explicit synonyms: Groups of words that are replaced by a second group of words. IE words on the left are replaced\n  (and expanded) into the words on the right. Example:\n    * \"pc => personal computer\"\n    * \"js => javascript, es6\"\n    * \"sea biscuit, sea biscit => seabiscuit\"\n* A maximum of 32 words can be added to a synonym",
+                "operationId": "synonym_rule_post",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SynonymRuleRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SynonymRule"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/{engine_name}/synonyms/{rule_id}": {
+            "get": {
+                "tags": [
+                    "synonyms"
+                ],
+                "summary": "Get Synonym Rule",
+                "description": "Retrieve a specific synonym by its ID.",
+                "operationId": "synonym_rule_get",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "rule_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Rule Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SynonymRule"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "synonyms"
+                ],
+                "summary": "Put Synonym Rule",
+                "description": "Create or update an existing synonym.\n\nOur synonym value format supports two styles of definition:\n\n* Equivalent synonyms: Groups of words, where any word in the group is a valid replacement. Example:\n    * \"ipod, i-pod, i pod\"\n    * \"computer, pc, laptop\"\n* Explicit synonyms: Groups of words that are replaced by a second group of words. IE words on the left are replaced\n  (and expanded) into the words on the right. Example:\n    * \"pc => personal computer\"\n    * \"js => javascript, es6\"\n    * \"sea biscuit, sea biscit => seabiscuit\"\n* A maximum of 32 words can be added to a synonym",
+                "operationId": "synonym_rule_put",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "rule_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Rule Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SynonymRuleRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SynonymRule"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "synonyms"
+                ],
+                "summary": "Delete Synonym Rule",
+                "description": "Delete an existing synonym value by its ID.",
+                "operationId": "synonym_rule_delete",
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "rule_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Rule Id"
+                        }
+                    },
+                    {
+                        "name": "engine_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^search-\\w+-\\w+-\\w+$",
+                            "title": "Your engine name (as provided by Silverstripe)"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseSuccess"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "BoostGetResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "title": "Id",
+                        "description": "ID of the boost"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/BoostType",
+                        "description": "Type of boost (value, proximity, functional)"
+                    },
+                    "impact": {
+                        "type": "number",
+                        "maximum": 10.0,
+                        "minimum": 0.0,
+                        "title": "Impact",
+                        "description": "Boost impact/factor (0-10, one decimal place)"
+                    },
+                    "values": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Values",
+                        "description": "Values to boost (for value boost type)"
+                    },
+                    "center": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Center",
+                        "description": "Center point for proximity calculation (for proximity boost type)"
+                    },
+                    "function": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Function",
+                        "description": "Function to apply (for proximity and functional boost types)"
+                    },
+                    "operation": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/FunctionalOperation"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "How to combine function result with score (for functional boost type)"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "type",
+                    "impact"
+                ],
+                "title": "BoostGetResponse",
+                "description": "Response model for fetching a boost."
+            },
+            "BoostPatchRequest": {
+                "properties": {
+                    "impact": {
+                        "anyOf": [
+                            {
+                                "type": "number",
+                                "maximum": 10.0,
+                                "minimum": 0.0,
+                                "description": "Boost impact/factor (0-10, one decimal place)"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Impact"
+                    },
+                    "values": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Values"
+                    },
+                    "center": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Center"
+                    },
+                    "function": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Function"
+                    },
+                    "operation": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/FunctionalOperation"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "title": "BoostPatchRequest",
+                "description": "Request model for updating an existing boost.\n\nAll fields are optional - only the fields provided will be updated.\nTo clear a field, explicitly set it to None or an empty value ([], \"\").\n\nNote: The boost type cannot be changed after creation."
+            },
+            "BoostPostRequest": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/BoostType",
+                        "description": "Type of boost to create (value, proximity, functional)"
+                    },
+                    "impact": {
+                        "type": "number",
+                        "maximum": 10.0,
+                        "minimum": 0.0,
+                        "title": "Impact",
+                        "description": "Boost impact/factor (0-10, one decimal place)"
+                    },
+                    "values": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Values",
+                        "description": "Values to boost (required for value boost type)"
+                    },
+                    "center": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Center",
+                        "description": "Center point for proximity calculation (required for proximity boost type)"
+                    },
+                    "function": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Function",
+                        "description": "Function to apply (required for proximity and functional boost types)"
+                    },
+                    "operation": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/FunctionalOperation"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "How to combine function result with score (required for functional boost type)"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "type",
+                    "impact"
+                ],
+                "title": "BoostPostRequest",
+                "description": "Request model for creating a new boost.\n\nThe boost_type determines which additional fields are required:\n- value: requires `values` (list of strings)\n- proximity: requires `center` and `function` (gaussian, exponential, linear)\n- functional: requires `function` (logarithmic, exponential, linear) and `operation`"
+            },
+            "BoostPostResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "title": "Id",
+                        "description": "ID of the created boost"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id"
+                ],
+                "title": "BoostPostResponse",
+                "description": "Response model for boost creation."
+            },
+            "BoostType": {
+                "type": "string",
+                "enum": [
+                    "value",
+                    "proximity",
+                    "functional"
+                ],
+                "title": "BoostType",
+                "description": "Types of boosts that can be applied to fields.\n\nValid combinations:\n- text: value\n- number: value, proximity, functional\n- date: value, proximity\n- geolocation: proximity"
+            },
+            "ClickRequest": {
+                "properties": {
+                    "request_id": {
+                        "type": "string",
+                        "title": "Request Id",
+                        "description": "The request_id from the original search response."
+                    },
+                    "document_id": {
+                        "type": "string",
+                        "title": "Document Id",
+                        "description": "The ID of the document that was clicked."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "request_id",
+                    "document_id"
+                ],
+                "title": "ClickRequest"
+            },
+            "Coordinate": {
+                "properties": {
+                    "latitude": {
+                        "anyOf": [
+                            {
+                                "type": "number",
+                                "maximum": 90.0,
+                                "minimum": -90.0
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "title": "Latitude"
+                    },
+                    "longitude": {
+                        "anyOf": [
+                            {
+                                "type": "number",
+                                "maximum": 180.0,
+                                "minimum": -180.0
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "title": "Longitude"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "latitude",
+                    "longitude"
+                ],
+                "title": "Coordinate"
+            },
+            "Document": {
+                "additionalProperties": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "type": "object",
+                "title": "Document",
+                "examples": [
+                    {
+                        "acres": "147237.02",
+                        "date_established": "1919-11-19T06:00:00Z",
+                        "description": "Lorem ipsum.",
+                        "id": "park_zion",
+                        "location": "37.3,-113.05",
+                        "nps_link": "https://www.nps.gov/zion/index.htm",
+                        "square_km": "595.8",
+                        "states": [
+                            "Utah"
+                        ],
+                        "title": "Zion",
+                        "visitors": "4295127",
+                        "world_heritage_site": "false"
+                    }
+                ]
+            },
+            "DocumentField": {
+                "properties": {
+                    "raw": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Raw"
+                    },
+                    "snippet": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "number"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Snippet"
+                    }
+                },
+                "type": "object",
+                "title": "DocumentField"
+            },
+            "DocumentListPagination": {
+                "properties": {
+                    "current": {
+                        "type": "integer",
+                        "minimum": 1.0,
+                        "title": "",
+                        "description": "Page number of results to return. Must be greater than or equal to 1.",
+                        "default": 1,
+                        "examples": [
+                            1
+                        ]
+                    },
+                    "size": {
+                        "type": "integer",
+                        "maximum": 100.0,
+                        "minimum": 1.0,
+                        "title": "",
+                        "description": "Number of results per page. Must be greater than or equal to 1 and less than or equal to 100. \n        Defaults to 10.",
+                        "default": 10,
+                        "examples": [
+                            5
+                        ]
+                    }
+                },
+                "type": "object",
+                "title": "DocumentListPagination"
+            },
+            "DocumentListRequest": {
+                "properties": {
+                    "page": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DocumentListPagination"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "default": {
+                            "current": 1,
+                            "size": 10
+                        }
+                    }
+                },
+                "type": "object",
+                "title": "DocumentListRequest"
+            },
+            "DocumentListResponse": {
+                "properties": {
+                    "meta": {
+                        "$ref": "#/components/schemas/DocumentListResponseMeta"
+                    },
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/Document"
+                        },
+                        "type": "array",
+                        "title": "Results"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "meta",
+                    "results"
+                ],
+                "title": "DocumentListResponse"
+            },
+            "DocumentListResponseMeta": {
+                "properties": {
+                    "alerts": {
+                        "anyOf": [
+                            {
+                                "items": {},
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Alerts"
+                    },
+                    "page": {
+                        "$ref": "#/components/schemas/PaginationResponse"
+                    },
+                    "request_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Request Id"
+                    },
+                    "warnings": {
+                        "anyOf": [
+                            {
+                                "items": {},
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Warnings"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "page"
+                ],
+                "title": "DocumentListResponseMeta"
+            },
+            "DocumentPostPatchResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "title": "Id"
+                    },
+                    "errors": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Errors"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id"
+                ],
+                "title": "DocumentPostPatchResponse",
+                "examples": [
+                    {
+                        "errors": [],
+                        "id": "park_zion"
+                    }
+                ]
+            },
+            "DocumentResponse": {
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/components/schemas/DocumentResponseMeta"
+                        },
+                        {
+                            "$ref": "#/components/schemas/DocumentField"
+                        }
+                    ]
+                },
+                "type": "object",
+                "title": "DocumentResponse",
+                "examples": [
+                    {
+                        "_meta": {
+                            "engine": "search-parks-main",
+                            "id": "park_everglades",
+                            "score": 1396363.1
+                        },
+                        "acres": {
+                            "raw": 1508968.1
+                        },
+                        "date_established": {
+                            "raw": "1934-05-30T05:00:00+00:00"
+                        },
+                        "description": {
+                            "raw": "The Everglades are the largest tropical wilderness in the United States."
+                        },
+                        "id": {
+                            "raw": "park_everglades"
+                        },
+                        "location": {
+                            "raw": "25.32,-80.93"
+                        },
+                        "nps_link": {
+                            "raw": "https://www.nps.gov/ever/index.htm"
+                        },
+                        "square_km": {
+                            "raw": 6106.6
+                        },
+                        "states": {
+                            "raw": [
+                                "Florida"
+                            ]
+                        },
+                        "title": {
+                            "raw": "Everglades"
+                        },
+                        "visitors": {
+                            "raw": 930907
+                        },
+                        "world_heritage_site": {
+                            "raw": "true"
+                        }
+                    }
+                ]
+            },
+            "DocumentResponseMeta": {
+                "properties": {
+                    "score": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Score"
+                    },
+                    "engine": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Engine"
+                    },
+                    "id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Id"
+                    }
+                },
+                "type": "object",
+                "title": "DocumentResponseMeta"
+            },
+            "DocumentsDeleteResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "title": "Id",
+                        "examples": [
+                            "park_zion"
+                        ]
+                    },
+                    "deleted": {
+                        "type": "boolean",
+                        "title": "Deleted",
+                        "examples": [
+                            true
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "deleted"
+                ],
+                "title": "DocumentsDeleteResponse"
+            },
+            "EngineName": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "examples": [
+                            "search-national-parks-demo"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "title": "EngineName"
+            },
+            "EnginesResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/EngineName"
+                        },
+                        "type": "array",
+                        "title": "Results"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "results"
+                ],
+                "title": "EnginesResponse"
+            },
+            "FacetResponse": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "value",
+                            "range"
+                        ],
+                        "title": "Type"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "data": {
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/ResponseFacetValue"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/ResponseFacetRange"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Data"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "type",
+                    "data"
+                ],
+                "title": "FacetResponse"
+            },
+            "FacetsRequest": {
+                "additionalProperties": {
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/RequestFacetValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/RequestFacetRange"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "type": "object",
+                "title": "FacetsRequest"
+            },
+            "FilterObjectLevel1": {
+                "properties": {
+                    "all": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel2"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "All"
+                    },
+                    "any": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel2"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Any"
+                    },
+                    "none": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel2"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "None"
+                    }
+                },
+                "type": "object",
+                "title": "FilterObjectLevel1"
+            },
+            "FilterObjectLevel2": {
+                "properties": {
+                    "all": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel3"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "All"
+                    },
+                    "any": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel3"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Any"
+                    },
+                    "none": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel3"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "None"
+                    }
+                },
+                "type": "object",
+                "title": "FilterObjectLevel2"
+            },
+            "FilterObjectLevel3": {
+                "properties": {
+                    "all": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel4"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "All"
+                    },
+                    "any": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel4"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Any"
+                    },
+                    "none": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel4"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "None"
+                    }
+                },
+                "type": "object",
+                "title": "FilterObjectLevel3"
+            },
+            "FilterObjectLevel4": {
+                "properties": {
+                    "all": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/ValueFilter"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "All"
+                    },
+                    "any": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/ValueFilter"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Any"
+                    },
+                    "none": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/ValueFilter"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "None"
+                    }
+                },
+                "type": "object",
+                "title": "FilterObjectLevel4"
+            },
+            "Filters": {
+                "properties": {
+                    "all": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel1"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "All"
+                    },
+                    "any": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel1"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Any"
+                    },
+                    "none": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ValueFilter"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/FilterObjectLevel1"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "None"
+                    }
+                },
+                "type": "object",
+                "title": "Filters",
+                "examples": [
+                    {
+                        "all": [
+                            {
+                                "date": {
+                                    "from": "2018-07-02",
+                                    "to": "2018-07-02"
+                                }
+                            },
+                            {
+                                "states": "Washington"
+                            },
+                            {
+                                "states": [
+                                    "Washington",
+                                    "Idaho"
+                                ]
+                            },
+                            {
+                                "location": {
+                                    "center": {
+                                        "latitude": -77.08,
+                                        "longitude": 38.89
+                                    },
+                                    "distance": 2,
+                                    "unit": "km"
+                                }
+                            }
+                        ],
+                        "any": [
+                            {
+                                "date": {
+                                    "from": "2018-07-02",
+                                    "to": "2018-07-02"
+                                }
+                            },
+                            {
+                                "states": "Washington"
+                            },
+                            {
+                                "states": [
+                                    "Washington",
+                                    "Idaho"
+                                ]
+                            },
+                            {
+                                "location": {
+                                    "center": {
+                                        "latitude": -77.08,
+                                        "longitude": 38.89
+                                    },
+                                    "from": 0,
+                                    "to": 1000,
+                                    "unit": "km"
+                                }
+                            }
+                        ],
+                        "none": [
+                            {
+                                "date": {
+                                    "from": "2018-07-02",
+                                    "to": "2018-07-02"
+                                }
+                            },
+                            {
+                                "states": "Washington"
+                            },
+                            {
+                                "states": [
+                                    "Washington",
+                                    "Idaho"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "FunctionalOperation": {
+                "type": "string",
+                "enum": [
+                    "multiply",
+                    "add"
+                ],
+                "title": "FunctionalOperation",
+                "description": "Operations available for functional boosts."
+            },
+            "Geo": {
+                "properties": {
+                    "from": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "From"
+                    },
+                    "to": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "To"
+                    },
+                    "center": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/Coordinate"
+                            },
+                            {
+                                "prefixItems": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "type": "array",
+                                "maxItems": 2,
+                                "minItems": 2
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "title": "Center"
+                    },
+                    "unit": {
+                        "$ref": "#/components/schemas/Unit"
+                    },
+                    "distance": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Distance"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "center",
+                    "unit"
+                ],
+                "title": "Geo"
+            },
+            "Geolocation": {
+                "properties": {
+                    "center": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/Coordinate"
+                            },
+                            {
+                                "prefixItems": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "type": "array",
+                                "maxItems": 2,
+                                "minItems": 2
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "title": "Center"
+                    },
+                    "order": {
+                        "type": "string",
+                        "enum": [
+                            "asc",
+                            "desc"
+                        ],
+                        "title": "Order"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "center",
+                    "order"
+                ],
+                "title": "Geolocation"
+            },
+            "HTTPValidationError": {
+                "properties": {
+                    "detail": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationError"
+                        },
+                        "type": "array",
+                        "title": "Detail"
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError"
+            },
+            "PaginationResponse": {
+                "properties": {
+                    "current": {
+                        "type": "integer",
+                        "title": "Current",
+                        "description": "Number representing the current page of results.",
+                        "examples": [
+                            1
+                        ]
+                    },
+                    "size": {
+                        "type": "integer",
+                        "title": "Size",
+                        "description": "Number representing the results per page.",
+                        "examples": [
+                            5
+                        ]
+                    },
+                    "total_pages": {
+                        "type": "integer",
+                        "title": "Total Pages",
+                        "description": "Number representing the total pages of results.\n        Value is 0 when you paginate beyond 10,000 results.",
+                        "examples": [
+                            5
+                        ]
+                    },
+                    "total_results": {
+                        "type": "integer",
+                        "title": "Total Results",
+                        "description": "Number representing the total results across all pages.\n        The values 0 through 9999 are exact counts.\n        The value 10000 is a pseudo keyword representing greater than or equal to 10,000 results.",
+                        "examples": [
+                            22
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "current",
+                    "size",
+                    "total_pages",
+                    "total_results"
+                ],
+                "title": "PaginationResponse"
+            },
+            "PostResponse": {
+                "properties": {
+                    "uuid": {
+                        "type": "string",
+                        "title": "Uuid"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "uuid"
+                ],
+                "title": "PostResponse"
+            },
+            "QuerySuggestionRequest": {
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "maxLength": 128,
+                        "title": "Query",
+                        "description": "A partial query for which to receive suggestions. Maximum length of 128 characters.",
+                        "examples": [
+                            "car"
+                        ]
+                    },
+                    "size": {
+                        "type": "integer",
+                        "maximum": 20.0,
+                        "minimum": 1.0,
+                        "title": "Size",
+                        "description": "Maximum number of query suggestions to return. Must be between 1 and 20. Defaults to 10.",
+                        "default": 10,
+                        "examples": [
+                            4
+                        ]
+                    },
+                    "fields": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Fields",
+                        "description": "Specify the document fields to look for suggestions within. Defaults to all text fields.",
+                        "examples": [
+                            [
+                                "title",
+                                "content"
+                            ]
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "query"
+                ],
+                "title": "QuerySuggestionRequest"
+            },
+            "QuerySuggestionResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/QuerySuggestionResponseValue"
+                        },
+                        "type": "array",
+                        "title": "Results"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "results"
+                ],
+                "title": "QuerySuggestionResponse",
+                "examples": [
+                    {
+                        "results": [
+                            {
+                                "raw": "carl's"
+                            },
+                            {
+                                "raw": "carl's caverns"
+                            },
+                            {
+                                "raw": "carolina"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "QuerySuggestionResponseValue": {
+                "properties": {
+                    "raw": {
+                        "type": "string",
+                        "title": "Raw"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "raw"
+                ],
+                "title": "QuerySuggestionResponseValue"
+            },
+            "Range": {
+                "properties": {
+                    "from": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "From"
+                    },
+                    "to": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "To"
+                    }
+                },
+                "type": "object",
+                "title": "Range"
+            },
+            "RequestFacetRange": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "value",
+                            "range"
+                        ],
+                        "title": "Type"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "ranges": {
+                        "items": {
+                            "$ref": "#/components/schemas/RequestFacetRangeObject"
+                        },
+                        "type": "array",
+                        "title": "Ranges"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "type",
+                    "ranges"
+                ],
+                "title": "RequestFacetRange"
+            },
+            "RequestFacetRangeObject": {
+                "properties": {
+                    "from": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "From"
+                    },
+                    "to": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "To"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    }
+                },
+                "type": "object",
+                "title": "RequestFacetRangeObject"
+            },
+            "RequestFacetValue": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "value",
+                            "range"
+                        ],
+                        "title": "Type"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "maximum": 100.0,
+                        "minimum": 1.0,
+                        "title": "Size",
+                        "default": 10
+                    },
+                    "sort": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/RequestFacetValueSort"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "type"
+                ],
+                "title": "RequestFacetValue"
+            },
+            "RequestFacetValueSort": {
+                "additionalProperties": {
+                    "type": "string",
+                    "enum": [
+                        "asc",
+                        "desc"
+                    ]
+                },
+                "propertyNames": {
+                    "enum": [
+                        "count",
+                        "value"
+                    ]
+                },
+                "type": "object",
+                "title": "RequestFacetValueSort"
+            },
+            "ResponseAcknowledged": {
+                "properties": {
+                    "acknowledged": {
+                        "type": "boolean",
+                        "title": "Acknowledged",
+                        "examples": [
+                            true
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "acknowledged"
+                ],
+                "title": "ResponseAcknowledged"
+            },
+            "ResponseConfirm": {
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "title": "Message"
+                    },
+                    "token": {
+                        "type": "integer",
+                        "title": "Token"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "message",
+                    "token"
+                ],
+                "title": "ResponseConfirm"
+            },
+            "ResponseFacetRange": {
+                "properties": {
+                    "from": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "From"
+                    },
+                    "to": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "To"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "count": {
+                        "type": "integer",
+                        "title": "Count"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "count"
+                ],
+                "title": "ResponseFacetRange"
+            },
+            "ResponseFacetValue": {
+                "properties": {
+                    "value": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            }
+                        ],
+                        "title": "Value"
+                    },
+                    "count": {
+                        "type": "integer",
+                        "title": "Count"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "value",
+                    "count"
+                ],
+                "title": "ResponseFacetValue"
+            },
+            "ResponseSuccess": {
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "title": "Success",
+                        "examples": [
+                            true
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "success"
+                ],
+                "title": "ResponseSuccess"
+            },
+            "Schema": {
+                "properties": {
+                    "_attachment": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "const": "binary"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Attachment"
+                    },
+                    "body": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "const": "text"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Body"
+                    }
+                },
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/ValidFields"
+                },
+                "type": "object",
+                "title": "Schema"
+            },
+            "SchemaGetResponse": {
+                "properties": {},
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/ValidFields"
+                },
+                "type": "object",
+                "title": "SchemaGetResponse"
+            },
+            "SearchRequest": {
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "maxLength": 128,
+                        "title": "Query",
+                        "examples": [
+                            "lorem"
+                        ]
+                    },
+                    "sort": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/Sort"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "page": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SearchRequestPagination"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "search_fields": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SearchRequestSearchFields"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "result_fields": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SearchRequestResultFields"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "facets": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/FacetsRequest"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "filters": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/Filters"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "boosts": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/SearchRequestBoost"
+                                    },
+                                    "type": "array"
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Boosts"
+                    },
+                    "analytics": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/Tags"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "record_analytics": {
+                        "type": "boolean",
+                        "title": "Record Analytics",
+                        "default": true
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "query"
+                ],
+                "title": "SearchRequest"
+            },
+            "SearchRequestBoost": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/BoostType",
+                        "description": "Type of boost (value, proximity, functional)"
+                    },
+                    "value": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Value",
+                        "description": "Values to boost on. Required for value boosts."
+                    },
+                    "factor": {
+                        "type": "number",
+                        "maximum": 10.0,
+                        "minimum": 0.0,
+                        "title": "Factor",
+                        "description": "Boost factor/impact (0-10). Defaults to 1.",
+                        "default": 1.0
+                    },
+                    "center": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Center",
+                        "description": "Center point for proximity boosts."
+                    },
+                    "function": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Function",
+                        "description": "Function for proximity (gaussian, exponential, linear) or functional (logarithmic, exponential, linear) boosts."
+                    },
+                    "operation": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/FunctionalOperation"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "How to combine function result with score (multiply, add). For functional boosts."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "type"
+                ],
+                "title": "SearchRequestBoost",
+                "description": "A boost definition provided at query time in the search request body.\n\nFollows the Elastic App Search boosts API format:\nhttps://www.elastic.co/guide/en/app-search/current/boosts.html\n\nThe boost type determines which additional fields are required:\n- value: requires `value` (list of strings/numbers to match)\n- proximity: requires `center` and `function`\n- functional: requires `function` and `operation`"
+            },
+            "SearchRequestPagination": {
+                "properties": {
+                    "current": {
+                        "type": "integer",
+                        "maximum": 100.0,
+                        "minimum": 1.0,
+                        "title": "",
+                        "description": "Page number of results to return. Must be greater than or equal to 1 and less than or equal to \n        100. Defaults to 1.",
+                        "default": 1,
+                        "examples": [
+                            1
+                        ]
+                    },
+                    "size": {
+                        "type": "integer",
+                        "maximum": 1000.0,
+                        "minimum": 1.0,
+                        "title": "",
+                        "description": "Number of results per page. Must be greater than or equal to 1 and less than or equal to 1000. \n        Defaults to 10.",
+                        "default": 10,
+                        "examples": [
+                            5
+                        ]
+                    }
+                },
+                "type": "object",
+                "title": "SearchRequestPagination"
+            },
+            "SearchRequestResultField": {
+                "properties": {
+                    "raw": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SearchRequestResultFieldRaw"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "snippet": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SearchRequestResultFieldSnippet"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "If given for a field type other than text, it will be silently ignored."
+                    }
+                },
+                "type": "object",
+                "title": "SearchRequestResultField"
+            },
+            "SearchRequestResultFieldRaw": {
+                "properties": {
+                    "size": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Size",
+                        "description": "Length of the return value (to the nearest word). Can only be used on text fields. If given for \n        a field type other than text, it will be silently ignored. Defaults to the entire text field."
+                    }
+                },
+                "type": "object",
+                "title": "SearchRequestResultFieldRaw"
+            },
+            "SearchRequestResultFieldSnippet": {
+                "properties": {
+                    "size": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Size",
+                        "description": "Character length of the snippet returned (to the nearest word). Must be at least 20; defaults to \n        100.",
+                        "default": 100
+                    },
+                    "fallback": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Fallback",
+                        "description": "If true, return the raw text field as the snippet (if no snippet is found). Defaults to true.",
+                        "default": true
+                    }
+                },
+                "type": "object",
+                "title": "SearchRequestResultFieldSnippet"
+            },
+            "SearchRequestResultFields": {
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/SearchRequestResultField"
+                },
+                "type": "object",
+                "title": "SearchRequestResultFields",
+                "examples": [
+                    {
+                        "description": {
+                            "raw": {
+                                "size": 200
+                            },
+                            "snippet": {
+                                "size": 100
+                            }
+                        },
+                        "states": {
+                            "raw": {},
+                            "snippet": {
+                                "fallback": false,
+                                "size": 20
+                            }
+                        },
+                        "title": {
+                            "snippet": {
+                                "fallback": true,
+                                "size": 20
+                            }
+                        }
+                    }
+                ]
+            },
+            "SearchRequestSearchFields": {
+                "anyOf": [
+                    {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/SearchRequestSearchFieldsWeight"
+                        },
+                        "type": "object"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ],
+                "title": "SearchRequestSearchFields",
+                "examples": [
+                    {
+                        "description": {
+                            "weight": 5
+                        },
+                        "states": {
+                            "weight": 3
+                        },
+                        "title": {
+                            "weight": 10
+                        }
+                    }
+                ]
+            },
+            "SearchRequestSearchFieldsWeight": {
+                "properties": {
+                    "weight": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Weight"
+                    }
+                },
+                "type": "object",
+                "title": "SearchRequestSearchFieldsWeight"
+            },
+            "SearchResponse": {
+                "properties": {
+                    "meta": {
+                        "$ref": "#/components/schemas/SearchResponseMeta"
+                    },
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/DocumentResponse"
+                        },
+                        "type": "array",
+                        "title": "Results"
+                    },
+                    "facets": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/FacetResponse"
+                                    },
+                                    "type": "array"
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Facets"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "meta",
+                    "results"
+                ],
+                "title": "SearchResponse"
+            },
+            "SearchResponseEngine": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "type": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Type"
+                    }
+                },
+                "type": "object",
+                "title": "SearchResponseEngine"
+            },
+            "SearchResponseMeta": {
+                "properties": {
+                    "warnings": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Warnings",
+                        "default": []
+                    },
+                    "precision": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Precision"
+                    },
+                    "engine": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SearchResponseEngine"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "request_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Request Id"
+                    },
+                    "page": {
+                        "$ref": "#/components/schemas/PaginationResponse"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "page"
+                ],
+                "title": "SearchResponseMeta"
+            },
+            "SettingsRequest": {
+                "properties": {
+                    "precision": {
+                        "type": "integer",
+                        "maximum": 11.0,
+                        "minimum": 1.0,
+                        "title": "Precision",
+                        "description": "Precision setting for your engine. Valid values are 1 - 11 (inclusive)",
+                        "examples": [
+                            2
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "precision"
+                ],
+                "title": "SettingsRequest"
+            },
+            "SettingsResponse": {
+                "properties": {
+                    "precision": {
+                        "type": "integer",
+                        "title": "Precision"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "precision"
+                ],
+                "title": "SettingsResponse"
+            },
+            "Sort": {
+                "anyOf": [
+                    {
+                        "items": {
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "string",
+                                        "enum": [
+                                            "asc",
+                                            "desc"
+                                        ]
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Geolocation"
+                                    }
+                                ]
+                            },
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ],
+                "title": "Sort",
+                "examples": [
+                    [
+                        {
+                            "_score": "desc"
+                        },
+                        {
+                            "title": "desc"
+                        },
+                        {
+                            "location": {
+                                "center": {
+                                    "latitude": -77.08,
+                                    "longitude": 38.89
+                                },
+                                "order": "asc"
+                            }
+                        }
+                    ]
+                ]
+            },
+            "SpellingSuggestionRequest": {
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "maxLength": 128,
+                        "title": "Query",
+                        "description": "A query for which to receive spelling suggestions. Maximum length of 128 characters.",
+                        "examples": [
+                            "caros"
+                        ]
+                    },
+                    "size": {
+                        "type": "integer",
+                        "maximum": 10.0,
+                        "minimum": 1.0,
+                        "title": "Size",
+                        "description": "Maximum number of spelling suggestions to return. Must be between 1 and 10. Defaults to 1.",
+                        "default": 1,
+                        "examples": [
+                            4
+                        ]
+                    },
+                    "fields": {
+                        "$ref": "#/components/schemas/ValidatedFields",
+                        "description": "Specify the document fields to look for suggestions within. At least 1 field is required.",
+                        "examples": [
+                            [
+                                "title",
+                                "content"
+                            ]
+                        ]
+                    },
+                    "formatted": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Formatted",
+                        "description": "Whether you would like a 'snippet' field to be returned with each of your results.",
+                        "default": false,
+                        "examples": [
+                            true
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "query",
+                    "fields"
+                ],
+                "title": "SpellingSuggestionRequest"
+            },
+            "SpellingSuggestionResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/DocumentField"
+                        },
+                        "type": "array",
+                        "title": "Results"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "results"
+                ],
+                "title": "SpellingSuggestionResponse",
+                "examples": [
+                    {
+                        "results": [
+                            {
+                                "raw": "carl's",
+                                "snippet": "<em>carl's</em>"
+                            },
+                            {
+                                "raw": "carolina",
+                                "snippet": "<em>carolina</em>"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "SynonymRule": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "title": "Id"
+                    },
+                    "synonyms": {
+                        "type": "string",
+                        "title": "Synonyms"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "synonyms"
+                ],
+                "title": "SynonymRule"
+            },
+            "SynonymRuleRequest": {
+                "properties": {
+                    "synonyms": {
+                        "type": "string",
+                        "title": "Synonyms"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "synonyms"
+                ],
+                "title": "SynonymRuleRequest"
+            },
+            "Tags": {
+                "properties": {
+                    "tags": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Tags",
+                        "description": "The Search endpoint can be used to attach tags to your documents. One or more tags can be applied \n        to filter results via the API or within your analytics dashboard.",
+                        "examples": [
+                            [
+                                "desktop",
+                                "mobile"
+                            ]
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "tags"
+                ],
+                "title": "Tags"
+            },
+            "Unit": {
+                "type": "string",
+                "enum": [
+                    "mm",
+                    "cm",
+                    "m",
+                    "km",
+                    "in",
+                    "ft",
+                    "yd",
+                    "mi"
+                ],
+                "title": "Unit"
+            },
+            "ValidFields": {
+                "type": "string",
+                "enum": [
+                    "text",
+                    "date",
+                    "geolocation",
+                    "number",
+                    "binary"
+                ],
+                "title": "ValidFields"
+            },
+            "ValidatedFields": {
+                "items": {
+                    "type": "string"
+                },
+                "type": "array",
+                "title": "ValidatedFields"
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Location"
+                    },
+                    "msg": {
+                        "type": "string",
+                        "title": "Message"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Error Type"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "title": "ValidationError"
+            },
+            "ValueFilter": {
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/components/schemas/Range"
+                        },
+                        {
+                            "$ref": "#/components/schemas/Geo"
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "type": "object",
+                "title": "ValueFilter"
+            },
+            "common__models__curation__get_response__GetResponse": {
+                "properties": {
+                    "uuid": {
+                        "type": "string",
+                        "title": "Uuid"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "queries": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/common__models__curation_query__get_response__GetResponse"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Queries",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "uuid"
+                ],
+                "title": "GetResponse"
+            },
+            "common__models__curation__patch_request__PatchRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 125
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    }
+                },
+                "type": "object",
+                "title": "PatchRequest"
+            },
+            "common__models__curation__post_request__PostRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 125
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "queries": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string",
+                                    "maxLength": 255,
+                                    "minLength": 1,
+                                    "pattern": "^\\S.*$",
+                                    "description": "Query strings cannot be empty or start with whitespace"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Queries",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "title": "PostRequest"
+            },
+            "common__models__curation_document__get_response__GetResponse": {
+                "properties": {
+                    "document_id": {
+                        "type": "string",
+                        "title": "Document Id"
+                    },
+                    "type": {
+                        "type": "integer",
+                        "title": "Type"
+                    },
+                    "sort": {
+                        "type": "integer",
+                        "title": "Sort"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "document_id",
+                    "type",
+                    "sort"
+                ],
+                "title": "GetResponse"
+            },
+            "common__models__curation_document__patch_request__PatchRequest": {
+                "properties": {
+                    "type": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "maximum": 1.0,
+                                "minimum": 0.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Type",
+                        "description": "Type of curation: 0 = HIDDEN, 1 = PROMOTED"
+                    },
+                    "sort": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Sort"
+                    }
+                },
+                "type": "object",
+                "title": "PatchRequest"
+            },
+            "common__models__curation_document__post_request__PostRequest": {
+                "properties": {
+                    "document_id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "pattern": "^\\S.*$",
+                        "title": "Document Id",
+                        "description": "Document ID cannot be empty or start with whitespace"
+                    },
+                    "type": {
+                        "type": "integer",
+                        "maximum": 1.0,
+                        "minimum": 0.0,
+                        "title": "Type",
+                        "description": "Type of curation: 0 = HIDDEN, 1 = PROMOTED"
+                    },
+                    "sort": {
+                        "type": "integer",
+                        "title": "Sort"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "document_id",
+                    "type",
+                    "sort"
+                ],
+                "title": "PostRequest"
+            },
+            "common__models__curation_query__get_response__GetResponse": {
+                "properties": {
+                    "uuid": {
+                        "type": "string",
+                        "title": "Uuid"
+                    },
+                    "query": {
+                        "type": "string",
+                        "title": "Query"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "uuid",
+                    "query"
+                ],
+                "title": "GetResponse"
+            },
+            "common__models__curation_query__post_request__PostRequest": {
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "minLength": 1,
+                        "title": "Query"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "query"
+                ],
+                "title": "PostRequest"
+            }
+        },
+        "securitySchemes": {
+            "HTTPBearer": {
+                "type": "http",
+                "scheme": "bearer"
+            }
+        }
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,342 @@ namespace Silverstripe\Search\Client;
 class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
 {
     /**
+     * Get all boosts for a field.
+     * @param string $fieldName Name of the field to get boosts for
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\BoostsGetNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostsGetUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\BoostGetResponse[] : \Psr\Http\Message\ResponseInterface)
+     */
+    public function boostsGet(string $fieldName, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\BoostsGet($fieldName, $engineName), $fetch);
+    }
+    /**
+     * Create a new boost for a field.
+     * @param string $fieldName Name of the field to add boost to
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\BoostPostRequest $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\BoostsPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostsPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\BoostPostResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function boostsPost(string $fieldName, string $engineName, \Silverstripe\Search\Client\Model\BoostPostRequest $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\BoostsPost($fieldName, $engineName, $requestBody), $fetch);
+    }
+    /**
+     * Delete a specific boost by its ID.
+     * @param string $fieldName Name of the field
+     * @param string $boostId ID of the boost to delete
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\BoostDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\ResponseSuccess : \Psr\Http\Message\ResponseInterface)
+     */
+    public function boostDelete(string $fieldName, string $boostId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\BoostDelete($fieldName, $boostId, $engineName), $fetch);
+    }
+    /**
+     * Get a specific boost by its ID.
+     * @param string $fieldName Name of the field
+     * @param string $boostId ID of the boost to retrieve
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\BoostGetNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostGetUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\BoostGetResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function boostGet(string $fieldName, string $boostId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\BoostGet($fieldName, $boostId, $engineName), $fetch);
+    }
+    /**
+     * Update a specific boost by its ID.
+     * @param string $fieldName Name of the field
+     * @param string $boostId ID of the boost to update
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\BoostPatchRequest $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\BoostPatchNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostPatchUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\BoostGetResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function boostPatch(string $fieldName, string $boostId, string $engineName, \Silverstripe\Search\Client\Model\BoostPatchRequest $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\BoostPatch($fieldName, $boostId, $engineName, $requestBody), $fetch);
+    }
+    /**
+     * Record a click event against a search result.
+     *
+     * **Body:**
+     *
+     * `request_id` **(required)**
+     * * The `request_id` returned in the `meta` of a search response.
+     *
+     * `document_id` **(required)**
+     * * The ID of the document that was clicked.
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\ClickRequest $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\ClickPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\ClickPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\ResponseSuccess : \Psr\Http\Message\ResponseInterface)
+     */
+    public function clickPost(string $engineName, \Silverstripe\Search\Client\Model\ClickRequest $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\ClickPost($engineName, $requestBody), $fetch);
+    }
+    /**
+     * Retrieve all curations for an engine.
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationsGetNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationsGetUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse[] : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationsGet(string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationsGet($engineName), $fetch);
+    }
+    /**
+     * Create a new curation for an engine.
+     *
+     * * `name`: An optional name for the curation. Can be useful in helping you easily identify the curation
+     * * `queries`: An optional list of query strings to be added to the curation at the time of creation
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationsPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationsPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\PostResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationsPost(string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationsPost($engineName, $requestBody), $fetch);
+    }
+    /**
+     * Delete a curation and all its related queries and documents.
+     * @param string $curationId
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\ResponseSuccess : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationDelete(string $curationId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationDelete($curationId, $engineName), $fetch);
+    }
+    /**
+     * Retrieve a specific curations for an engine.
+     * @param string $curationId
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationGetNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationGetUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationGet(string $curationId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationGet($curationId, $engineName), $fetch);
+    }
+    /**
+     * Update a curation's details. Only provided fields are updated.
+     *
+     * * `name`: An optional name for the curation
+     * @param string $curationId
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationPatchNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationPatchUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationPatch(string $curationId, string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationPatch($curationId, $engineName, $requestBody), $fetch);
+    }
+    /**
+     * Retrieve all documents for a curation.
+     * @param string $curationId
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsGetAllNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsGetAllUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse[] : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationDocumentsGetAll(string $curationId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationDocumentsGetAll($curationId, $engineName), $fetch);
+    }
+    /**
+     * Add a document to a curation.
+     *
+     * The 'type' field determines how the document is curated:
+     * - 0 (HIDDEN): Document is hidden from search results for this curation
+     * - 1 (PROMOTED): Document is promoted in search results for this curation
+     *
+     * A maximum of 20 Documents can be added for each Curation Type (HIDDEN, PROMOTED).
+     * @param string $curationId
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationDocumentsPost(string $curationId, string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationDocumentsPost($curationId, $engineName, $requestBody), $fetch);
+    }
+    /**
+     * Remove a document from a curation.
+     * @param string $curationId
+     * @param string $documentId
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\ResponseSuccess : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationDocumentsDelete(string $curationId, string $documentId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationDocumentsDelete($curationId, $documentId, $engineName), $fetch);
+    }
+    /**
+     * Retrieve a specific document for a curation.
+     * @param string $curationId
+     * @param string $documentId
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsGetOneNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsGetOneUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationDocumentsGetOne(string $curationId, string $documentId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationDocumentsGetOne($curationId, $documentId, $engineName), $fetch);
+    }
+    /**
+     * Update a document in a curation.
+     *
+     * Only the fields provided in the request will be updated:
+     * - type: 0 (HIDDEN) or 1 (PROMOTED)
+     * - sort: The sort order for the document
+     * @param string $curationId
+     * @param string $documentId
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsPatchNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsPatchUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationDocumentsPatch(string $curationId, string $documentId, string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationDocumentsPatch($curationId, $documentId, $engineName, $requestBody), $fetch);
+    }
+    /**
+     * Retrieve all queries for a curation.
+     * @param string $curationId
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesGetAllNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesGetAllUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse[] : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationQueriesGetAll(string $curationId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationQueriesGetAll($curationId, $engineName), $fetch);
+    }
+    /**
+     * Create a new query for an existing curation.
+     * @param string $curationId
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest $requestBody
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\PostResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationQueriesPost(string $curationId, string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationQueriesPost($curationId, $engineName, $requestBody), $fetch);
+    }
+    /**
+     * Delete a query from a curation.
+     * @param string $curationId
+     * @param string $queryId
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\ResponseSuccess : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationQueriesDelete(string $curationId, string $queryId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationQueriesDelete($curationId, $queryId, $engineName), $fetch);
+    }
+    /**
+     * Retrieve a specific query for a curation.
+     * @param string $curationId
+     * @param string $queryId
+     * @param string $engineName
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesGetOneNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesGetOneUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse : \Psr\Http\Message\ResponseInterface)
+     */
+    public function curationQueriesGetOne(string $curationId, string $queryId, string $engineName, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\CurationQueriesGetOne($curationId, $queryId, $engineName), $fetch);
+    }
+    /**
      * Delete documents by `id`.
      * @param string $engineName
      * @param array[] $requestBody
@@ -13,7 +349,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\DocumentsDeleteUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\DocumentsDeleteResponse[]|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\DocumentsDeleteResponse[] : \Psr\Http\Message\ResponseInterface)
      */
     public function documentsDelete(string $engineName, array $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -33,7 +369,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\DocumentsGetUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return null|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
      */
     public function documentsGet(string $engineName, array $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -52,7 +388,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\DocumentsPatchUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\DocumentPostPatchResponse[]|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\DocumentPostPatchResponse[] : \Psr\Http\Message\ResponseInterface)
      */
     public function documentsPatch(string $engineName, array $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -81,7 +417,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\DocumentsPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\DocumentPostPatchResponse[]|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\DocumentPostPatchResponse[] : \Psr\Http\Message\ResponseInterface)
      */
     public function documentsPost(string $engineName, array $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -91,17 +427,17 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * **Body:**
      *
      * `page` (optional)
-     * * Object to delimit the pagination parameters.
+     * * Object to delimit the pagination parameters
      *
      * `page.size` (optional)
-     * * Number of results per page.
-     * * Must be greater than or equal to 1 and less than or equal to 100.
-     * * Defaults to 10.
+     * * Number of results per page
+     * * Must be greater than or equal to 1 and less than or equal to 100
+     * * Defaults to 10
      *
      * `page.current` (optional)
-     * * Page number of results to return.
-     * * Must be greater than or equal to 1 and less than or equal to 100.
-     * * Defaults to 1.
+     * * Page number of results to return
+     * * Must be greater than or equal to 1
+     * * Defaults to 1
      * @param string $engineName
      * @param null|mixed $requestBody
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
@@ -109,7 +445,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\DocumentsListPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\DocumentListResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\DocumentListResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function documentsListPost(string $engineName, $requestBody = null, string $fetch = self::FETCH_OBJECT)
     {
@@ -120,7 +456,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\EnginesPostNotFoundException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\EnginesResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\EnginesResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function enginesPost(string $fetch = self::FETCH_OBJECT)
     {
@@ -148,11 +484,30 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\QuerySuggestionPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\QuerySuggestionResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\QuerySuggestionResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function querySuggestionPost(string $engineName, \Silverstripe\Search\Client\Model\QuerySuggestionRequest $requestBody, string $fetch = self::FETCH_OBJECT)
     {
         return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\QuerySuggestionPost($engineName, $requestBody), $fetch);
+    }
+    /**
+     * Deletes all schema fields for the engine, resetting it to an empty schema and engine.
+     *
+     * **Important:** Deleting the schema will also result in all Documents within the engine being deleted.
+     * @param string $engineName
+     * @param array{
+     *    "token"?: mixed,
+     * } $queryParameters
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Silverstripe\Search\Client\Exception\SchemaDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\SchemaDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     */
+    public function schemaDelete(string $engineName, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Silverstripe\Search\Client\Endpoint\SchemaDelete($engineName, $queryParameters), $fetch);
     }
     /**
      * @param string $engineName
@@ -161,7 +516,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SchemaGetUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\Schema|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SchemaGetResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function schemaGet(string $engineName, string $fetch = self::FETCH_OBJECT)
     {
@@ -204,7 +559,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SchemaPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SchemaPostResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\ResponseAcknowledged : \Psr\Http\Message\ResponseInterface)
      */
     public function schemaPost(string $engineName, \Silverstripe\Search\Client\Model\Schema $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -218,6 +573,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * `query` **(required)**
      * * String or number to match
      * * The value '' (empty string) matches all documents
+     * * maximum length of 128 characters
      * * The following Lucene query syntax is supported:
      *     * double-quoted strings
      *     * `+` and `-`
@@ -228,7 +584,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      *
      * `page.size` (optional)
      * * Number of results per page
-     * * Must be greater than or equal to 1 and less than or equal to 100
+     * * Must be greater than or equal to 1 and less than or equal to 1000
      * * Defaults to 10.
      *
      * `page.current` (optional)
@@ -298,6 +654,44 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      *     * `date`: Value filter, Range filter
      *     * `geolocation`: Geo filter
      *
+     * `boosts` (optional)
+     * * Apply boosts to influence the relevance scoring of results at query time
+     * * JSON object where the key is a field name and the value is an array of boost objects
+     * * Query-time boosts completely replace any stored boosts configured for the engine
+     * * The following boost types are available based on field type:
+     *     * `text`: Value boost
+     *     * `number`: Value boost, Proximity boost
+     *     * `date`: Value boost, Proximity boost (recency)
+     *     * `geolocation`: Proximity boost
+     *
+     * `boosts.{field_key}` **(required)**
+     * * The field from your schema upon which to apply your boost
+     * * Must contain an array of {boost_object}.
+     *
+     * `{boost_object}.type` **(required)**
+     * * Type of boost: "value" or "proximity"
+     *
+     * `{boost_object}.value` **(required for value boosts)**
+     * * An array of string values to match against
+     * * Documents with matching values in the boosted field will have their relevance score increased.
+     *
+     * `{boost_object}.center` **(required for proximity boosts)**
+     * * The center point from which to calculate distance
+     * * For date fields: a date string (e.g. "2024-01-01") or a relative date expression.
+     *   Supported formats: "now", "now-1d", "now-7d", "now-1M", "now-1y", "now/d" (rounded to start of day)
+     * * For number fields: a numeric string (e.g. "100")
+     * * For geolocation fields: a lat,lon string (e.g. "-36.8485,174.7633")
+     *
+     * `{boost_object}.function` **(required for proximity boosts)**
+     * * The decay function to use: "gaussian", "exponential", or "linear"
+     * * Gaussian provides a smooth bell-curve decay
+     * * Exponential provides a sharp initial decay that flattens over distance
+     * * Linear provides a constant rate of decay
+     *
+     * `{boost_object}.factor` (optional)
+     * * The strength of the boost, between 0 and 10
+     * * Defaults to 1.
+     *
      * `search_fields` (optional)
      * * The search_fields parameter restricts a query to search only specific fields
      * * Restricting fields will result in faster queries, especially for schemas with many text fields
@@ -344,14 +738,17 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      *
      * `analytics` (optional)
      * * Object to delimit the analytics parameters.
+     * * Only available to Analyst and Architect plans.
      *
      * `analytics.tags` **(required)**
      * * Array of strings representing the tags you’d like to apply to the query
      * * You may submit up to 16 tags, and each may be up to 64 characters in length.
+     * * Only available to Analyst and Architect plans.
      *
      * `record_analytics` (optional)
      * * If `true`, generates an analytics query event for the search request
      * * Defaults to `true`.
+     * * Only available to Analyst and Architect plans.
      * @param string $engineName
      * @param \Silverstripe\Search\Client\Model\SearchRequest $requestBody
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
@@ -359,7 +756,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SearchPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return null|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SearchResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function searchPost(string $engineName, \Silverstripe\Search\Client\Model\SearchRequest $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -372,7 +769,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SettingsGetUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SettingsResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SettingsResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function settingsGet(string $engineName, string $fetch = self::FETCH_OBJECT)
     {
@@ -402,7 +799,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SettingsPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SettingsResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SettingsResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function settingsPost(string $engineName, \Silverstripe\Search\Client\Model\SettingsRequest $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -431,7 +828,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SpellingSuggestionPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SpellingSuggestionResponse|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SpellingSuggestionResponse : \Psr\Http\Message\ResponseInterface)
      */
     public function spellingSuggestionPost(string $engineName, \Silverstripe\Search\Client\Model\SpellingSuggestionRequest $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -445,7 +842,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SynonymRulesGetUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SynonymRule[]|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SynonymRule[] : \Psr\Http\Message\ResponseInterface)
      */
     public function synonymRulesGet(string $engineName, string $fetch = self::FETCH_OBJECT)
     {
@@ -472,7 +869,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SynonymRulePostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SynonymRule|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SynonymRule : \Psr\Http\Message\ResponseInterface)
      */
     public function synonymRulePost(string $engineName, \Silverstripe\Search\Client\Model\SynonymRuleRequest $requestBody, string $fetch = self::FETCH_OBJECT)
     {
@@ -487,7 +884,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SynonymRuleDeleteUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\ResponseSuccess|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\ResponseSuccess : \Psr\Http\Message\ResponseInterface)
      */
     public function synonymRuleDelete(string $ruleId, string $engineName, string $fetch = self::FETCH_OBJECT)
     {
@@ -502,7 +899,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SynonymRuleGetUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SynonymRule|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SynonymRule : \Psr\Http\Message\ResponseInterface)
      */
     public function synonymRuleGet(string $ruleId, string $engineName, string $fetch = self::FETCH_OBJECT)
     {
@@ -530,7 +927,7 @@ class Client extends \Silverstripe\Search\Client\Runtime\Client\Client
      * @throws \Silverstripe\Search\Client\Exception\SynonymRulePutUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SynonymRule|\Psr\Http\Message\ResponseInterface
+     * @return ($fetch is 'object' ? \Silverstripe\Search\Client\Model\SynonymRule : \Psr\Http\Message\ResponseInterface)
      */
     public function synonymRulePut(string $ruleId, string $engineName, \Silverstripe\Search\Client\Model\SynonymRuleRequest $requestBody, string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Endpoint/BoostDelete.php
+++ b/src/Endpoint/BoostDelete.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class BoostDelete extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $field_name;
+    protected $boost_id;
+    protected $engine_name;
+    /**
+     * Delete a specific boost by its ID.
+     * @param string $fieldName Name of the field
+     * @param string $boostId ID of the boost to delete
+     * @param string $engineName
+     */
+    public function __construct(string $fieldName, string $boostId, string $engineName)
+    {
+        $this->field_name = $fieldName;
+        $this->boost_id = $boostId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{field_name}', '{boost_id}', '{engine_name}'], [$this->field_name, $this->boost_id, $this->engine_name], '/{engine_name}/field/{field_name}/boosts/{boost_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\BoostDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\ResponseSuccess
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\ResponseSuccess', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\BoostDeleteNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\BoostDeleteUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/BoostGet.php
+++ b/src/Endpoint/BoostGet.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class BoostGet extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $field_name;
+    protected $boost_id;
+    protected $engine_name;
+    /**
+     * Get a specific boost by its ID.
+     * @param string $fieldName Name of the field
+     * @param string $boostId ID of the boost to retrieve
+     * @param string $engineName
+     */
+    public function __construct(string $fieldName, string $boostId, string $engineName)
+    {
+        $this->field_name = $fieldName;
+        $this->boost_id = $boostId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{field_name}', '{boost_id}', '{engine_name}'], [$this->field_name, $this->boost_id, $this->engine_name], '/{engine_name}/field/{field_name}/boosts/{boost_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\BoostGetNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostGetUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\BoostGetResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\BoostGetResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\BoostGetNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\BoostGetUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/BoostPatch.php
+++ b/src/Endpoint/BoostPatch.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class BoostPatch extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $field_name;
+    protected $boost_id;
+    protected $engine_name;
+    /**
+     * Update a specific boost by its ID.
+     * @param string $fieldName Name of the field
+     * @param string $boostId ID of the boost to update
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\BoostPatchRequest $requestBody
+     */
+    public function __construct(string $fieldName, string $boostId, string $engineName, \Silverstripe\Search\Client\Model\BoostPatchRequest $requestBody)
+    {
+        $this->field_name = $fieldName;
+        $this->boost_id = $boostId;
+        $this->engine_name = $engineName;
+        $this->body = $requestBody;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'PATCH';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{field_name}', '{boost_id}', '{engine_name}'], [$this->field_name, $this->boost_id, $this->engine_name], '/{engine_name}/field/{field_name}/boosts/{boost_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Silverstripe\Search\Client\Model\BoostPatchRequest) {
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\BoostPatchNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostPatchUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\BoostGetResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\BoostGetResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\BoostPatchNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\BoostPatchUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/BoostsGet.php
+++ b/src/Endpoint/BoostsGet.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class BoostsGet extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $field_name;
+    protected $engine_name;
+    /**
+     * Get all boosts for a field.
+     * @param string $fieldName Name of the field to get boosts for
+     * @param string $engineName
+     */
+    public function __construct(string $fieldName, string $engineName)
+    {
+        $this->field_name = $fieldName;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{field_name}', '{engine_name}'], [$this->field_name, $this->engine_name], '/{engine_name}/field/{field_name}/boosts');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\BoostsGetNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostsGetUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\BoostGetResponse[]
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\BoostGetResponse[]', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\BoostsGetNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\BoostsGetUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/BoostsPost.php
+++ b/src/Endpoint/BoostsPost.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class BoostsPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $field_name;
+    protected $engine_name;
+    /**
+     * Create a new boost for a field.
+     * @param string $fieldName Name of the field to add boost to
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\BoostPostRequest $requestBody
+     */
+    public function __construct(string $fieldName, string $engineName, \Silverstripe\Search\Client\Model\BoostPostRequest $requestBody)
+    {
+        $this->field_name = $fieldName;
+        $this->engine_name = $engineName;
+        $this->body = $requestBody;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{field_name}', '{engine_name}'], [$this->field_name, $this->engine_name], '/{engine_name}/field/{field_name}/boosts');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Silverstripe\Search\Client\Model\BoostPostRequest) {
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\BoostsPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\BoostsPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\BoostPostResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\BoostPostResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\BoostsPostNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\BoostsPostUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/ClickPost.php
+++ b/src/Endpoint/ClickPost.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class ClickPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $engine_name;
+    /**
+     * Record a click event against a search result.
+     *
+     * **Body:**
+     *
+     * `request_id` **(required)**
+     * * The `request_id` returned in the `meta` of a search response.
+     *
+     * `document_id` **(required)**
+     * * The ID of the document that was clicked.
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\ClickRequest $requestBody
+     */
+    public function __construct(string $engineName, \Silverstripe\Search\Client\Model\ClickRequest $requestBody)
+    {
+        $this->engine_name = $engineName;
+        $this->body = $requestBody;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{engine_name}'], [$this->engine_name], '/{engine_name}/click');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Silverstripe\Search\Client\Model\ClickRequest) {
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\ClickPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\ClickPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\ResponseSuccess
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\ResponseSuccess', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\ClickPostNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\ClickPostUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationDelete.php
+++ b/src/Endpoint/CurationDelete.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationDelete extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $engine_name;
+    /**
+     * Delete a curation and all its related queries and documents.
+     * @param string $curationId
+     * @param string $engineName
+     */
+    public function __construct(string $curationId, string $engineName)
+    {
+        $this->curation_id = $curationId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{engine_name}'], [$this->curation_id, $this->engine_name], '/{engine_name}/curations/{curation_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\ResponseSuccess
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\ResponseSuccess', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDeleteNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDeleteUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationDocumentsDelete.php
+++ b/src/Endpoint/CurationDocumentsDelete.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationDocumentsDelete extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $document_id;
+    protected $engine_name;
+    /**
+     * Remove a document from a curation.
+     * @param string $curationId
+     * @param string $documentId
+     * @param string $engineName
+     */
+    public function __construct(string $curationId, string $documentId, string $engineName)
+    {
+        $this->curation_id = $curationId;
+        $this->document_id = $documentId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{document_id}', '{engine_name}'], [$this->curation_id, $this->document_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/documents/{document_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\ResponseSuccess
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\ResponseSuccess', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsDeleteNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsDeleteUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationDocumentsGetAll.php
+++ b/src/Endpoint/CurationDocumentsGetAll.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationDocumentsGetAll extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $engine_name;
+    /**
+     * Retrieve all documents for a curation.
+     * @param string $curationId
+     * @param string $engineName
+     */
+    public function __construct(string $curationId, string $engineName)
+    {
+        $this->curation_id = $curationId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{engine_name}'], [$this->curation_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/documents');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsGetAllNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsGetAllUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse[]
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse[]', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsGetAllNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsGetAllUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationDocumentsGetOne.php
+++ b/src/Endpoint/CurationDocumentsGetOne.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationDocumentsGetOne extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $document_id;
+    protected $engine_name;
+    /**
+     * Retrieve a specific document for a curation.
+     * @param string $curationId
+     * @param string $documentId
+     * @param string $engineName
+     */
+    public function __construct(string $curationId, string $documentId, string $engineName)
+    {
+        $this->curation_id = $curationId;
+        $this->document_id = $documentId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{document_id}', '{engine_name}'], [$this->curation_id, $this->document_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/documents/{document_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsGetOneNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsGetOneUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsGetOneNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsGetOneUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationDocumentsPatch.php
+++ b/src/Endpoint/CurationDocumentsPatch.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationDocumentsPatch extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $document_id;
+    protected $engine_name;
+    /**
+     * Update a document in a curation.
+     *
+     * Only the fields provided in the request will be updated:
+     * - type: 0 (HIDDEN) or 1 (PROMOTED)
+     * - sort: The sort order for the document
+     * @param string $curationId
+     * @param string $documentId
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest $requestBody
+     */
+    public function __construct(string $curationId, string $documentId, string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest $requestBody)
+    {
+        $this->curation_id = $curationId;
+        $this->document_id = $documentId;
+        $this->engine_name = $engineName;
+        $this->body = $requestBody;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'PATCH';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{document_id}', '{engine_name}'], [$this->curation_id, $this->document_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/documents/{document_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest) {
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsPatchNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsPatchUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsPatchNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsPatchUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationDocumentsPost.php
+++ b/src/Endpoint/CurationDocumentsPost.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationDocumentsPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $engine_name;
+    /**
+     * Add a document to a curation.
+     *
+     * The 'type' field determines how the document is curated:
+     * - 0 (HIDDEN): Document is hidden from search results for this curation
+     * - 1 (PROMOTED): Document is promoted in search results for this curation
+     *
+     * A maximum of 20 Documents can be added for each Curation Type (HIDDEN, PROMOTED).
+     * @param string $curationId
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest $requestBody
+     */
+    public function __construct(string $curationId, string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest $requestBody)
+    {
+        $this->curation_id = $curationId;
+        $this->engine_name = $engineName;
+        $this->body = $requestBody;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{engine_name}'], [$this->curation_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/documents');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest) {
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationDocumentsPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsPostNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationDocumentsPostUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationGet.php
+++ b/src/Endpoint/CurationGet.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationGet extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $engine_name;
+    /**
+     * Retrieve a specific curations for an engine.
+     * @param string $curationId
+     * @param string $engineName
+     */
+    public function __construct(string $curationId, string $engineName)
+    {
+        $this->curation_id = $curationId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{engine_name}'], [$this->curation_id, $this->engine_name], '/{engine_name}/curations/{curation_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationGetNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationGetUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationGetNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationGetUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationPatch.php
+++ b/src/Endpoint/CurationPatch.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationPatch extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $engine_name;
+    /**
+     * Update a curation's details. Only provided fields are updated.
+     *
+     * * `name`: An optional name for the curation
+     * @param string $curationId
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest $requestBody
+     */
+    public function __construct(string $curationId, string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest $requestBody)
+    {
+        $this->curation_id = $curationId;
+        $this->engine_name = $engineName;
+        $this->body = $requestBody;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'PATCH';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{engine_name}'], [$this->curation_id, $this->engine_name], '/{engine_name}/curations/{curation_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest) {
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationPatchNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationPatchUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationPatchNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationPatchUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationQueriesDelete.php
+++ b/src/Endpoint/CurationQueriesDelete.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationQueriesDelete extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $query_id;
+    protected $engine_name;
+    /**
+     * Delete a query from a curation.
+     * @param string $curationId
+     * @param string $queryId
+     * @param string $engineName
+     */
+    public function __construct(string $curationId, string $queryId, string $engineName)
+    {
+        $this->curation_id = $curationId;
+        $this->query_id = $queryId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{query_id}', '{engine_name}'], [$this->curation_id, $this->query_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/queries/{query_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\ResponseSuccess
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\ResponseSuccess', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationQueriesDeleteNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationQueriesDeleteUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationQueriesGetAll.php
+++ b/src/Endpoint/CurationQueriesGetAll.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationQueriesGetAll extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $engine_name;
+    /**
+     * Retrieve all queries for a curation.
+     * @param string $curationId
+     * @param string $engineName
+     */
+    public function __construct(string $curationId, string $engineName)
+    {
+        $this->curation_id = $curationId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{engine_name}'], [$this->curation_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/queries');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesGetAllNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesGetAllUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse[]
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse[]', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationQueriesGetAllNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationQueriesGetAllUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationQueriesGetOne.php
+++ b/src/Endpoint/CurationQueriesGetOne.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationQueriesGetOne extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $query_id;
+    protected $engine_name;
+    /**
+     * Retrieve a specific query for a curation.
+     * @param string $curationId
+     * @param string $queryId
+     * @param string $engineName
+     */
+    public function __construct(string $curationId, string $queryId, string $engineName)
+    {
+        $this->curation_id = $curationId;
+        $this->query_id = $queryId;
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{query_id}', '{engine_name}'], [$this->curation_id, $this->query_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/queries/{query_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesGetOneNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesGetOneUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationQueriesGetOneNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationQueriesGetOneUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationQueriesPost.php
+++ b/src/Endpoint/CurationQueriesPost.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationQueriesPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $curation_id;
+    protected $engine_name;
+    /**
+     * Create a new query for an existing curation.
+     * @param string $curationId
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest $requestBody
+     */
+    public function __construct(string $curationId, string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest $requestBody)
+    {
+        $this->curation_id = $curationId;
+        $this->engine_name = $engineName;
+        $this->body = $requestBody;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{curation_id}', '{engine_name}'], [$this->curation_id, $this->engine_name], '/{engine_name}/curations/{curation_id}/queries');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest) {
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationQueriesPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\PostResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\PostResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationQueriesPostNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationQueriesPostUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationsGet.php
+++ b/src/Endpoint/CurationsGet.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationsGet extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $engine_name;
+    /**
+     * Retrieve all curations for an engine.
+     * @param string $engineName
+     */
+    public function __construct(string $engineName)
+    {
+        $this->engine_name = $engineName;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{engine_name}'], [$this->engine_name], '/{engine_name}/curations');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationsGetNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationsGetUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse[]
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse[]', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationsGetNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationsGetUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/CurationsPost.php
+++ b/src/Endpoint/CurationsPost.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class CurationsPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $engine_name;
+    /**
+     * Create a new curation for an engine.
+     *
+     * * `name`: An optional name for the curation. Can be useful in helping you easily identify the curation
+     * * `queries`: An optional list of query strings to be added to the curation at the time of creation
+     * @param string $engineName
+     * @param \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest $requestBody
+     */
+    public function __construct(string $engineName, \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest $requestBody)
+    {
+        $this->engine_name = $engineName;
+        $this->body = $requestBody;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{engine_name}'], [$this->engine_name], '/{engine_name}/curations');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if ($this->body instanceof \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest) {
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\CurationsPostNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\CurationsPostUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return \Silverstripe\Search\Client\Model\PostResponse
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\PostResponse', 'json');
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\CurationsPostNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\CurationsPostUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/DocumentsListPost.php
+++ b/src/Endpoint/DocumentsListPost.php
@@ -9,17 +9,17 @@ class DocumentsListPost extends \Silverstripe\Search\Client\Runtime\Client\BaseE
      * **Body:**
      *
      * `page` (optional)
-     * * Object to delimit the pagination parameters.
+     * * Object to delimit the pagination parameters
      *
      * `page.size` (optional)
-     * * Number of results per page.
-     * * Must be greater than or equal to 1 and less than or equal to 100.
-     * * Defaults to 10.
+     * * Number of results per page
+     * * Must be greater than or equal to 1 and less than or equal to 100
+     * * Defaults to 10
      *
      * `page.current` (optional)
-     * * Page number of results to return.
-     * * Must be greater than or equal to 1 and less than or equal to 100.
-     * * Defaults to 1.
+     * * Page number of results to return
+     * * Must be greater than or equal to 1
+     * * Defaults to 1
      * @param string $engineName
      * @param null|mixed $requestBody
      */

--- a/src/Endpoint/SchemaDelete.php
+++ b/src/Endpoint/SchemaDelete.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Silverstripe\Search\Client\Endpoint;
+
+class SchemaDelete extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint implements \Silverstripe\Search\Client\Runtime\Client\Endpoint
+{
+    protected $engine_name;
+    /**
+     * Deletes all schema fields for the engine, resetting it to an empty schema and engine.
+     *
+     * **Important:** Deleting the schema will also result in all Documents within the engine being deleted.
+     * @param string $engineName
+     * @param array{
+     *    "token"?: mixed,
+     * } $queryParameters
+     */
+    public function __construct(string $engineName, array $queryParameters = [])
+    {
+        $this->engine_name = $engineName;
+        $this->queryParameters = $queryParameters;
+    }
+    use \Silverstripe\Search\Client\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{engine_name}'], [$this->engine_name], '/{engine_name}/schema');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['token']);
+        $optionsResolver->setRequired([]);
+        $optionsResolver->setDefaults([]);
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Silverstripe\Search\Client\Exception\SchemaDeleteNotFoundException
+     * @throws \Silverstripe\Search\Client\Exception\SchemaDeleteUnprocessableEntityException
+     * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+        if (404 === $status) {
+            throw new \Silverstripe\Search\Client\Exception\SchemaDeleteNotFoundException($response);
+        }
+        if (is_null($contentType) === false && (422 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Silverstripe\Search\Client\Exception\SchemaDeleteUnprocessableEntityException($serializer->deserialize($body, 'Silverstripe\Search\Client\Model\HTTPValidationError', 'json'), $response);
+        }
+        throw new \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException($status, $body);
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return ['HTTPBearer'];
+    }
+}

--- a/src/Endpoint/SchemaGet.php
+++ b/src/Endpoint/SchemaGet.php
@@ -36,14 +36,14 @@ class SchemaGet extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint 
      * @throws \Silverstripe\Search\Client\Exception\SchemaGetUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\Schema
+     * @return \Silverstripe\Search\Client\Model\SchemaGetResponse
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
         $status = $response->getStatusCode();
         $body = (string) $response->getBody();
         if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
-            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\Schema', 'json');
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\SchemaGetResponse', 'json');
         }
         if (404 === $status) {
             throw new \Silverstripe\Search\Client\Exception\SchemaGetNotFoundException($response);

--- a/src/Endpoint/SchemaPost.php
+++ b/src/Endpoint/SchemaPost.php
@@ -70,14 +70,14 @@ class SchemaPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint
      * @throws \Silverstripe\Search\Client\Exception\SchemaPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return \Silverstripe\Search\Client\Model\SchemaPostResponse
+     * @return \Silverstripe\Search\Client\Model\ResponseAcknowledged
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
         $status = $response->getStatusCode();
         $body = (string) $response->getBody();
         if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
-            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\SchemaPostResponse', 'json');
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\ResponseAcknowledged', 'json');
         }
         if (404 === $status) {
             throw new \Silverstripe\Search\Client\Exception\SchemaPostNotFoundException($response);

--- a/src/Endpoint/SearchPost.php
+++ b/src/Endpoint/SearchPost.php
@@ -13,6 +13,7 @@ class SearchPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint
      * `query` **(required)**
      * * String or number to match
      * * The value '' (empty string) matches all documents
+     * * maximum length of 128 characters
      * * The following Lucene query syntax is supported:
      *     * double-quoted strings
      *     * `+` and `-`
@@ -23,7 +24,7 @@ class SearchPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint
      *
      * `page.size` (optional)
      * * Number of results per page
-     * * Must be greater than or equal to 1 and less than or equal to 100
+     * * Must be greater than or equal to 1 and less than or equal to 1000
      * * Defaults to 10.
      *
      * `page.current` (optional)
@@ -93,6 +94,44 @@ class SearchPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint
      *     * `date`: Value filter, Range filter
      *     * `geolocation`: Geo filter
      *
+     * `boosts` (optional)
+     * * Apply boosts to influence the relevance scoring of results at query time
+     * * JSON object where the key is a field name and the value is an array of boost objects
+     * * Query-time boosts completely replace any stored boosts configured for the engine
+     * * The following boost types are available based on field type:
+     *     * `text`: Value boost
+     *     * `number`: Value boost, Proximity boost
+     *     * `date`: Value boost, Proximity boost (recency)
+     *     * `geolocation`: Proximity boost
+     *
+     * `boosts.{field_key}` **(required)**
+     * * The field from your schema upon which to apply your boost
+     * * Must contain an array of {boost_object}.
+     *
+     * `{boost_object}.type` **(required)**
+     * * Type of boost: "value" or "proximity"
+     *
+     * `{boost_object}.value` **(required for value boosts)**
+     * * An array of string values to match against
+     * * Documents with matching values in the boosted field will have their relevance score increased.
+     *
+     * `{boost_object}.center` **(required for proximity boosts)**
+     * * The center point from which to calculate distance
+     * * For date fields: a date string (e.g. "2024-01-01") or a relative date expression.
+     *   Supported formats: "now", "now-1d", "now-7d", "now-1M", "now-1y", "now/d" (rounded to start of day)
+     * * For number fields: a numeric string (e.g. "100")
+     * * For geolocation fields: a lat,lon string (e.g. "-36.8485,174.7633")
+     *
+     * `{boost_object}.function` **(required for proximity boosts)**
+     * * The decay function to use: "gaussian", "exponential", or "linear"
+     * * Gaussian provides a smooth bell-curve decay
+     * * Exponential provides a sharp initial decay that flattens over distance
+     * * Linear provides a constant rate of decay
+     *
+     * `{boost_object}.factor` (optional)
+     * * The strength of the boost, between 0 and 10
+     * * Defaults to 1.
+     *
      * `search_fields` (optional)
      * * The search_fields parameter restricts a query to search only specific fields
      * * Restricting fields will result in faster queries, especially for schemas with many text fields
@@ -139,14 +178,17 @@ class SearchPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint
      *
      * `analytics` (optional)
      * * Object to delimit the analytics parameters.
+     * * Only available to Analyst and Architect plans.
      *
      * `analytics.tags` **(required)**
      * * Array of strings representing the tags you’d like to apply to the query
      * * You may submit up to 16 tags, and each may be up to 64 characters in length.
+     * * Only available to Analyst and Architect plans.
      *
      * `record_analytics` (optional)
      * * If `true`, generates an analytics query event for the search request
      * * Defaults to `true`.
+     * * Only available to Analyst and Architect plans.
      * @param string $engineName
      * @param \Silverstripe\Search\Client\Model\SearchRequest $requestBody
      */
@@ -182,14 +224,14 @@ class SearchPost extends \Silverstripe\Search\Client\Runtime\Client\BaseEndpoint
      * @throws \Silverstripe\Search\Client\Exception\SearchPostUnprocessableEntityException
      * @throws \Silverstripe\Search\Client\Exception\UnexpectedStatusCodeException
      *
-     * @return null
+     * @return \Silverstripe\Search\Client\Model\SearchResponse
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
         $status = $response->getStatusCode();
         $body = (string) $response->getBody();
         if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
-            return json_decode($body);
+            return $serializer->deserialize($body, 'Silverstripe\Search\Client\Model\SearchResponse', 'json');
         }
         if (404 === $status) {
             throw new \Silverstripe\Search\Client\Exception\SearchPostNotFoundException($response);

--- a/src/Exception/BoostDeleteNotFoundException.php
+++ b/src/Exception/BoostDeleteNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostDeleteNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostDeleteUnprocessableEntityException.php
+++ b/src/Exception/BoostDeleteUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostDeleteUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostGetNotFoundException.php
+++ b/src/Exception/BoostGetNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostGetNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostGetUnprocessableEntityException.php
+++ b/src/Exception/BoostGetUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostGetUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostPatchNotFoundException.php
+++ b/src/Exception/BoostPatchNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostPatchNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostPatchUnprocessableEntityException.php
+++ b/src/Exception/BoostPatchUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostPatchUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostsGetNotFoundException.php
+++ b/src/Exception/BoostsGetNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostsGetNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostsGetUnprocessableEntityException.php
+++ b/src/Exception/BoostsGetUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostsGetUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostsPostNotFoundException.php
+++ b/src/Exception/BoostsPostNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostsPostNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/BoostsPostUnprocessableEntityException.php
+++ b/src/Exception/BoostsPostUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class BoostsPostUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/ClickPostNotFoundException.php
+++ b/src/Exception/ClickPostNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class ClickPostNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/ClickPostUnprocessableEntityException.php
+++ b/src/Exception/ClickPostUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class ClickPostUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDeleteNotFoundException.php
+++ b/src/Exception/CurationDeleteNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDeleteNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDeleteUnprocessableEntityException.php
+++ b/src/Exception/CurationDeleteUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDeleteUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsDeleteNotFoundException.php
+++ b/src/Exception/CurationDocumentsDeleteNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsDeleteNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsDeleteUnprocessableEntityException.php
+++ b/src/Exception/CurationDocumentsDeleteUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsDeleteUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsGetAllNotFoundException.php
+++ b/src/Exception/CurationDocumentsGetAllNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsGetAllNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsGetAllUnprocessableEntityException.php
+++ b/src/Exception/CurationDocumentsGetAllUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsGetAllUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsGetOneNotFoundException.php
+++ b/src/Exception/CurationDocumentsGetOneNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsGetOneNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsGetOneUnprocessableEntityException.php
+++ b/src/Exception/CurationDocumentsGetOneUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsGetOneUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsPatchNotFoundException.php
+++ b/src/Exception/CurationDocumentsPatchNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsPatchNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsPatchUnprocessableEntityException.php
+++ b/src/Exception/CurationDocumentsPatchUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsPatchUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsPostNotFoundException.php
+++ b/src/Exception/CurationDocumentsPostNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsPostNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationDocumentsPostUnprocessableEntityException.php
+++ b/src/Exception/CurationDocumentsPostUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationDocumentsPostUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationGetNotFoundException.php
+++ b/src/Exception/CurationGetNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationGetNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationGetUnprocessableEntityException.php
+++ b/src/Exception/CurationGetUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationGetUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationPatchNotFoundException.php
+++ b/src/Exception/CurationPatchNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationPatchNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationPatchUnprocessableEntityException.php
+++ b/src/Exception/CurationPatchUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationPatchUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationQueriesDeleteNotFoundException.php
+++ b/src/Exception/CurationQueriesDeleteNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationQueriesDeleteNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationQueriesDeleteUnprocessableEntityException.php
+++ b/src/Exception/CurationQueriesDeleteUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationQueriesDeleteUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationQueriesGetAllNotFoundException.php
+++ b/src/Exception/CurationQueriesGetAllNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationQueriesGetAllNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationQueriesGetAllUnprocessableEntityException.php
+++ b/src/Exception/CurationQueriesGetAllUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationQueriesGetAllUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationQueriesGetOneNotFoundException.php
+++ b/src/Exception/CurationQueriesGetOneNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationQueriesGetOneNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationQueriesGetOneUnprocessableEntityException.php
+++ b/src/Exception/CurationQueriesGetOneUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationQueriesGetOneUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationQueriesPostNotFoundException.php
+++ b/src/Exception/CurationQueriesPostNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationQueriesPostNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationQueriesPostUnprocessableEntityException.php
+++ b/src/Exception/CurationQueriesPostUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationQueriesPostUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationsGetNotFoundException.php
+++ b/src/Exception/CurationsGetNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationsGetNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationsGetUnprocessableEntityException.php
+++ b/src/Exception/CurationsGetUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationsGetUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationsPostNotFoundException.php
+++ b/src/Exception/CurationsPostNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationsPostNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/CurationsPostUnprocessableEntityException.php
+++ b/src/Exception/CurationsPostUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class CurationsPostUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/DocumentsDeleteNotFoundException.php
+++ b/src/Exception/DocumentsDeleteNotFoundException.php
@@ -8,7 +8,7 @@ class DocumentsDeleteNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/DocumentsGetNotFoundException.php
+++ b/src/Exception/DocumentsGetNotFoundException.php
@@ -8,7 +8,7 @@ class DocumentsGetNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/DocumentsListPostNotFoundException.php
+++ b/src/Exception/DocumentsListPostNotFoundException.php
@@ -8,7 +8,7 @@ class DocumentsListPostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/DocumentsPatchNotFoundException.php
+++ b/src/Exception/DocumentsPatchNotFoundException.php
@@ -8,7 +8,7 @@ class DocumentsPatchNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/DocumentsPostNotFoundException.php
+++ b/src/Exception/DocumentsPostNotFoundException.php
@@ -8,7 +8,7 @@ class DocumentsPostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/EnginesPostNotFoundException.php
+++ b/src/Exception/EnginesPostNotFoundException.php
@@ -8,7 +8,7 @@ class EnginesPostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/QuerySuggestionPostNotFoundException.php
+++ b/src/Exception/QuerySuggestionPostNotFoundException.php
@@ -8,7 +8,7 @@ class QuerySuggestionPostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SchemaDeleteNotFoundException.php
+++ b/src/Exception/SchemaDeleteNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class SchemaDeleteNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/SchemaDeleteUnprocessableEntityException.php
+++ b/src/Exception/SchemaDeleteUnprocessableEntityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Silverstripe\Search\Client\Exception;
+
+class SchemaDeleteUnprocessableEntityException extends UnprocessableEntityException
+{
+    /**
+     * @var \Silverstripe\Search\Client\Model\HTTPValidationError
+     */
+    private $hTTPValidationError;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Silverstripe\Search\Client\Model\HTTPValidationError $hTTPValidationError, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Validation Error');
+        $this->hTTPValidationError = $hTTPValidationError;
+        $this->response = $response;
+    }
+    public function getHTTPValidationError(): \Silverstripe\Search\Client\Model\HTTPValidationError
+    {
+        return $this->hTTPValidationError;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Exception/SchemaGetNotFoundException.php
+++ b/src/Exception/SchemaGetNotFoundException.php
@@ -8,7 +8,7 @@ class SchemaGetNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SchemaPostNotFoundException.php
+++ b/src/Exception/SchemaPostNotFoundException.php
@@ -8,7 +8,7 @@ class SchemaPostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SearchPostNotFoundException.php
+++ b/src/Exception/SearchPostNotFoundException.php
@@ -8,7 +8,7 @@ class SearchPostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SettingsGetNotFoundException.php
+++ b/src/Exception/SettingsGetNotFoundException.php
@@ -8,7 +8,7 @@ class SettingsGetNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SettingsPostNotFoundException.php
+++ b/src/Exception/SettingsPostNotFoundException.php
@@ -8,7 +8,7 @@ class SettingsPostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SpellingSuggestionPostNotFoundException.php
+++ b/src/Exception/SpellingSuggestionPostNotFoundException.php
@@ -8,7 +8,7 @@ class SpellingSuggestionPostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SynonymRuleDeleteNotFoundException.php
+++ b/src/Exception/SynonymRuleDeleteNotFoundException.php
@@ -8,7 +8,7 @@ class SynonymRuleDeleteNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SynonymRuleGetNotFoundException.php
+++ b/src/Exception/SynonymRuleGetNotFoundException.php
@@ -8,7 +8,7 @@ class SynonymRuleGetNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SynonymRulePostNotFoundException.php
+++ b/src/Exception/SynonymRulePostNotFoundException.php
@@ -8,7 +8,7 @@ class SynonymRulePostNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SynonymRulePutNotFoundException.php
+++ b/src/Exception/SynonymRulePutNotFoundException.php
@@ -8,7 +8,7 @@ class SynonymRulePutNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Exception/SynonymRulesGetNotFoundException.php
+++ b/src/Exception/SynonymRulesGetNotFoundException.php
@@ -8,7 +8,7 @@ class SynonymRulesGetNotFoundException extends NotFoundException
      * @var \Psr\Http\Message\ResponseInterface
      */
     private $response;
-    public function __construct(\Psr\Http\Message\ResponseInterface $response = null)
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
     {
         parent::__construct('Not found');
         $this->response = $response;

--- a/src/Model/BoostGetResponse.php
+++ b/src/Model/BoostGetResponse.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class BoostGetResponse
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * ID of the boost
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * Types of boosts that can be applied to fields.
+     * 
+     * Valid combinations:
+     * - text: value
+     * - number: value, proximity, functional
+     * - date: value, proximity
+     * - geolocation: proximity
+     *
+     * @var string
+     */
+    protected $type;
+    /**
+     * Boost impact/factor (0-10, one decimal place)
+     *
+     * @var float
+     */
+    protected $impact;
+    /**
+     * Values to boost (for value boost type)
+     *
+     * @var mixed|null
+     */
+    protected $values;
+    /**
+     * Center point for proximity calculation (for proximity boost type)
+     *
+     * @var mixed|null
+     */
+    protected $center;
+    /**
+     * Function to apply (for proximity and functional boost types)
+     *
+     * @var mixed|null
+     */
+    protected $function;
+    /**
+     * How to combine function result with score (for functional boost type)
+     *
+     * @var string|null
+     */
+    protected $operation;
+    /**
+     * ID of the boost
+     *
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * ID of the boost
+     *
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * Types of boosts that can be applied to fields.
+     * 
+     * Valid combinations:
+     * - text: value
+     * - number: value, proximity, functional
+     * - date: value, proximity
+     * - geolocation: proximity
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+    /**
+    * Types of boosts that can be applied to fields.
+    
+    Valid combinations:
+    - text: value
+    - number: value, proximity, functional
+    - date: value, proximity
+    - geolocation: proximity
+    *
+    * @param string $type
+    *
+    * @return self
+    */
+    public function setType(string $type): self
+    {
+        $this->initialized['type'] = true;
+        $this->type = $type;
+        return $this;
+    }
+    /**
+     * Boost impact/factor (0-10, one decimal place)
+     *
+     * @return float
+     */
+    public function getImpact(): float
+    {
+        return $this->impact;
+    }
+    /**
+     * Boost impact/factor (0-10, one decimal place)
+     *
+     * @param float $impact
+     *
+     * @return self
+     */
+    public function setImpact(float $impact): self
+    {
+        $this->initialized['impact'] = true;
+        $this->impact = $impact;
+        return $this;
+    }
+    /**
+     * Values to boost (for value boost type)
+     *
+     * @return mixed
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+    /**
+     * Values to boost (for value boost type)
+     *
+     * @param mixed $values
+     *
+     * @return self
+     */
+    public function setValues($values): self
+    {
+        $this->initialized['values'] = true;
+        $this->values = $values;
+        return $this;
+    }
+    /**
+     * Center point for proximity calculation (for proximity boost type)
+     *
+     * @return mixed
+     */
+    public function getCenter()
+    {
+        return $this->center;
+    }
+    /**
+     * Center point for proximity calculation (for proximity boost type)
+     *
+     * @param mixed $center
+     *
+     * @return self
+     */
+    public function setCenter($center): self
+    {
+        $this->initialized['center'] = true;
+        $this->center = $center;
+        return $this;
+    }
+    /**
+     * Function to apply (for proximity and functional boost types)
+     *
+     * @return mixed
+     */
+    public function getFunction()
+    {
+        return $this->function;
+    }
+    /**
+     * Function to apply (for proximity and functional boost types)
+     *
+     * @param mixed $function
+     *
+     * @return self
+     */
+    public function setFunction($function): self
+    {
+        $this->initialized['function'] = true;
+        $this->function = $function;
+        return $this;
+    }
+    /**
+     * How to combine function result with score (for functional boost type)
+     *
+     * @return string|null
+     */
+    public function getOperation(): ?string
+    {
+        return $this->operation;
+    }
+    /**
+     * How to combine function result with score (for functional boost type)
+     *
+     * @param string|null $operation
+     *
+     * @return self
+     */
+    public function setOperation(?string $operation): self
+    {
+        $this->initialized['operation'] = true;
+        $this->operation = $operation;
+        return $this;
+    }
+}

--- a/src/Model/BoostPatchRequest.php
+++ b/src/Model/BoostPatchRequest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class BoostPatchRequest
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var mixed|null
+     */
+    protected $impact;
+    /**
+     * @var mixed|null
+     */
+    protected $values;
+    /**
+     * @var mixed|null
+     */
+    protected $center;
+    /**
+     * @var mixed|null
+     */
+    protected $function;
+    /**
+     * @var string|null
+     */
+    protected $operation;
+    /**
+     * @return mixed
+     */
+    public function getImpact()
+    {
+        return $this->impact;
+    }
+    /**
+     * @param mixed $impact
+     *
+     * @return self
+     */
+    public function setImpact($impact): self
+    {
+        $this->initialized['impact'] = true;
+        $this->impact = $impact;
+        return $this;
+    }
+    /**
+     * @return mixed
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+    /**
+     * @param mixed $values
+     *
+     * @return self
+     */
+    public function setValues($values): self
+    {
+        $this->initialized['values'] = true;
+        $this->values = $values;
+        return $this;
+    }
+    /**
+     * @return mixed
+     */
+    public function getCenter()
+    {
+        return $this->center;
+    }
+    /**
+     * @param mixed $center
+     *
+     * @return self
+     */
+    public function setCenter($center): self
+    {
+        $this->initialized['center'] = true;
+        $this->center = $center;
+        return $this;
+    }
+    /**
+     * @return mixed
+     */
+    public function getFunction()
+    {
+        return $this->function;
+    }
+    /**
+     * @param mixed $function
+     *
+     * @return self
+     */
+    public function setFunction($function): self
+    {
+        $this->initialized['function'] = true;
+        $this->function = $function;
+        return $this;
+    }
+    /**
+     * @return string|null
+     */
+    public function getOperation(): ?string
+    {
+        return $this->operation;
+    }
+    /**
+     * @param string|null $operation
+     *
+     * @return self
+     */
+    public function setOperation(?string $operation): self
+    {
+        $this->initialized['operation'] = true;
+        $this->operation = $operation;
+        return $this;
+    }
+}

--- a/src/Model/BoostPostRequest.php
+++ b/src/Model/BoostPostRequest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class BoostPostRequest
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * Types of boosts that can be applied to fields.
+     * 
+     * Valid combinations:
+     * - text: value
+     * - number: value, proximity, functional
+     * - date: value, proximity
+     * - geolocation: proximity
+     *
+     * @var string
+     */
+    protected $type;
+    /**
+     * Boost impact/factor (0-10, one decimal place)
+     *
+     * @var float
+     */
+    protected $impact;
+    /**
+     * Values to boost (required for value boost type)
+     *
+     * @var mixed|null
+     */
+    protected $values;
+    /**
+     * Center point for proximity calculation (required for proximity boost type)
+     *
+     * @var mixed|null
+     */
+    protected $center;
+    /**
+     * Function to apply (required for proximity and functional boost types)
+     *
+     * @var mixed|null
+     */
+    protected $function;
+    /**
+     * How to combine function result with score (required for functional boost type)
+     *
+     * @var string|null
+     */
+    protected $operation;
+    /**
+     * Types of boosts that can be applied to fields.
+     * 
+     * Valid combinations:
+     * - text: value
+     * - number: value, proximity, functional
+     * - date: value, proximity
+     * - geolocation: proximity
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+    /**
+    * Types of boosts that can be applied to fields.
+    
+    Valid combinations:
+    - text: value
+    - number: value, proximity, functional
+    - date: value, proximity
+    - geolocation: proximity
+    *
+    * @param string $type
+    *
+    * @return self
+    */
+    public function setType(string $type): self
+    {
+        $this->initialized['type'] = true;
+        $this->type = $type;
+        return $this;
+    }
+    /**
+     * Boost impact/factor (0-10, one decimal place)
+     *
+     * @return float
+     */
+    public function getImpact(): float
+    {
+        return $this->impact;
+    }
+    /**
+     * Boost impact/factor (0-10, one decimal place)
+     *
+     * @param float $impact
+     *
+     * @return self
+     */
+    public function setImpact(float $impact): self
+    {
+        $this->initialized['impact'] = true;
+        $this->impact = $impact;
+        return $this;
+    }
+    /**
+     * Values to boost (required for value boost type)
+     *
+     * @return mixed
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+    /**
+     * Values to boost (required for value boost type)
+     *
+     * @param mixed $values
+     *
+     * @return self
+     */
+    public function setValues($values): self
+    {
+        $this->initialized['values'] = true;
+        $this->values = $values;
+        return $this;
+    }
+    /**
+     * Center point for proximity calculation (required for proximity boost type)
+     *
+     * @return mixed
+     */
+    public function getCenter()
+    {
+        return $this->center;
+    }
+    /**
+     * Center point for proximity calculation (required for proximity boost type)
+     *
+     * @param mixed $center
+     *
+     * @return self
+     */
+    public function setCenter($center): self
+    {
+        $this->initialized['center'] = true;
+        $this->center = $center;
+        return $this;
+    }
+    /**
+     * Function to apply (required for proximity and functional boost types)
+     *
+     * @return mixed
+     */
+    public function getFunction()
+    {
+        return $this->function;
+    }
+    /**
+     * Function to apply (required for proximity and functional boost types)
+     *
+     * @param mixed $function
+     *
+     * @return self
+     */
+    public function setFunction($function): self
+    {
+        $this->initialized['function'] = true;
+        $this->function = $function;
+        return $this;
+    }
+    /**
+     * How to combine function result with score (required for functional boost type)
+     *
+     * @return string|null
+     */
+    public function getOperation(): ?string
+    {
+        return $this->operation;
+    }
+    /**
+     * How to combine function result with score (required for functional boost type)
+     *
+     * @param string|null $operation
+     *
+     * @return self
+     */
+    public function setOperation(?string $operation): self
+    {
+        $this->initialized['operation'] = true;
+        $this->operation = $operation;
+        return $this;
+    }
+}

--- a/src/Model/BoostPostResponse.php
+++ b/src/Model/BoostPostResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class BoostPostResponse
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * ID of the created boost
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * ID of the created boost
+     *
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * ID of the created boost
+     *
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+}

--- a/src/Model/ClickRequest.php
+++ b/src/Model/ClickRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class ClickRequest
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * The request_id from the original search response.
+     *
+     * @var string
+     */
+    protected $requestId;
+    /**
+     * The ID of the document that was clicked.
+     *
+     * @var string
+     */
+    protected $documentId;
+    /**
+     * The request_id from the original search response.
+     *
+     * @return string
+     */
+    public function getRequestId(): string
+    {
+        return $this->requestId;
+    }
+    /**
+     * The request_id from the original search response.
+     *
+     * @param string $requestId
+     *
+     * @return self
+     */
+    public function setRequestId(string $requestId): self
+    {
+        $this->initialized['requestId'] = true;
+        $this->requestId = $requestId;
+        return $this;
+    }
+    /**
+     * The ID of the document that was clicked.
+     *
+     * @return string
+     */
+    public function getDocumentId(): string
+    {
+        return $this->documentId;
+    }
+    /**
+     * The ID of the document that was clicked.
+     *
+     * @param string $documentId
+     *
+     * @return self
+     */
+    public function setDocumentId(string $documentId): self
+    {
+        $this->initialized['documentId'] = true;
+        $this->documentId = $documentId;
+        return $this;
+    }
+}

--- a/src/Model/CommonModelsCurationDocumentGetResponseGetResponse.php
+++ b/src/Model/CommonModelsCurationDocumentGetResponseGetResponse.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class CommonModelsCurationDocumentGetResponseGetResponse
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $documentId;
+    /**
+     * @var int
+     */
+    protected $type;
+    /**
+     * @var int
+     */
+    protected $sort;
+    /**
+     * @return string
+     */
+    public function getDocumentId(): string
+    {
+        return $this->documentId;
+    }
+    /**
+     * @param string $documentId
+     *
+     * @return self
+     */
+    public function setDocumentId(string $documentId): self
+    {
+        $this->initialized['documentId'] = true;
+        $this->documentId = $documentId;
+        return $this;
+    }
+    /**
+     * @return int
+     */
+    public function getType(): int
+    {
+        return $this->type;
+    }
+    /**
+     * @param int $type
+     *
+     * @return self
+     */
+    public function setType(int $type): self
+    {
+        $this->initialized['type'] = true;
+        $this->type = $type;
+        return $this;
+    }
+    /**
+     * @return int
+     */
+    public function getSort(): int
+    {
+        return $this->sort;
+    }
+    /**
+     * @param int $sort
+     *
+     * @return self
+     */
+    public function setSort(int $sort): self
+    {
+        $this->initialized['sort'] = true;
+        $this->sort = $sort;
+        return $this;
+    }
+}

--- a/src/Model/CommonModelsCurationDocumentPatchRequestPatchRequest.php
+++ b/src/Model/CommonModelsCurationDocumentPatchRequestPatchRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class CommonModelsCurationDocumentPatchRequestPatchRequest
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * Type of curation: 0 = HIDDEN, 1 = PROMOTED
+     *
+     * @var mixed|null
+     */
+    protected $type;
+    /**
+     * @var mixed|null
+     */
+    protected $sort;
+    /**
+     * Type of curation: 0 = HIDDEN, 1 = PROMOTED
+     *
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+    /**
+     * Type of curation: 0 = HIDDEN, 1 = PROMOTED
+     *
+     * @param mixed $type
+     *
+     * @return self
+     */
+    public function setType($type): self
+    {
+        $this->initialized['type'] = true;
+        $this->type = $type;
+        return $this;
+    }
+    /**
+     * @return mixed
+     */
+    public function getSort()
+    {
+        return $this->sort;
+    }
+    /**
+     * @param mixed $sort
+     *
+     * @return self
+     */
+    public function setSort($sort): self
+    {
+        $this->initialized['sort'] = true;
+        $this->sort = $sort;
+        return $this;
+    }
+}

--- a/src/Model/CommonModelsCurationDocumentPostRequestPostRequest.php
+++ b/src/Model/CommonModelsCurationDocumentPostRequestPostRequest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class CommonModelsCurationDocumentPostRequestPostRequest
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * Document ID cannot be empty or start with whitespace
+     *
+     * @var string
+     */
+    protected $documentId;
+    /**
+     * Type of curation: 0 = HIDDEN, 1 = PROMOTED
+     *
+     * @var int
+     */
+    protected $type;
+    /**
+     * @var int
+     */
+    protected $sort;
+    /**
+     * Document ID cannot be empty or start with whitespace
+     *
+     * @return string
+     */
+    public function getDocumentId(): string
+    {
+        return $this->documentId;
+    }
+    /**
+     * Document ID cannot be empty or start with whitespace
+     *
+     * @param string $documentId
+     *
+     * @return self
+     */
+    public function setDocumentId(string $documentId): self
+    {
+        $this->initialized['documentId'] = true;
+        $this->documentId = $documentId;
+        return $this;
+    }
+    /**
+     * Type of curation: 0 = HIDDEN, 1 = PROMOTED
+     *
+     * @return int
+     */
+    public function getType(): int
+    {
+        return $this->type;
+    }
+    /**
+     * Type of curation: 0 = HIDDEN, 1 = PROMOTED
+     *
+     * @param int $type
+     *
+     * @return self
+     */
+    public function setType(int $type): self
+    {
+        $this->initialized['type'] = true;
+        $this->type = $type;
+        return $this;
+    }
+    /**
+     * @return int
+     */
+    public function getSort(): int
+    {
+        return $this->sort;
+    }
+    /**
+     * @param int $sort
+     *
+     * @return self
+     */
+    public function setSort(int $sort): self
+    {
+        $this->initialized['sort'] = true;
+        $this->sort = $sort;
+        return $this;
+    }
+}

--- a/src/Model/CommonModelsCurationGetResponseGetResponse.php
+++ b/src/Model/CommonModelsCurationGetResponseGetResponse.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class CommonModelsCurationGetResponseGetResponse
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $uuid;
+    /**
+     * @var mixed|null
+     */
+    protected $name;
+    /**
+     * @var mixed|null
+     */
+    protected $queries;
+    /**
+     * @return string
+     */
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+    /**
+     * @param string $uuid
+     *
+     * @return self
+     */
+    public function setUuid(string $uuid): self
+    {
+        $this->initialized['uuid'] = true;
+        $this->uuid = $uuid;
+        return $this;
+    }
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+    /**
+     * @param mixed $name
+     *
+     * @return self
+     */
+    public function setName($name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return mixed
+     */
+    public function getQueries()
+    {
+        return $this->queries;
+    }
+    /**
+     * @param mixed $queries
+     *
+     * @return self
+     */
+    public function setQueries($queries): self
+    {
+        $this->initialized['queries'] = true;
+        $this->queries = $queries;
+        return $this;
+    }
+}

--- a/src/Model/CommonModelsCurationPatchRequestPatchRequest.php
+++ b/src/Model/CommonModelsCurationPatchRequestPatchRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class CommonModelsCurationPatchRequestPatchRequest
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var mixed|null
+     */
+    protected $name;
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+    /**
+     * @param mixed $name
+     *
+     * @return self
+     */
+    public function setName($name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/src/Model/CommonModelsCurationPostRequestPostRequest.php
+++ b/src/Model/CommonModelsCurationPostRequestPostRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class CommonModelsCurationPostRequestPostRequest
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var mixed|null
+     */
+    protected $name;
+    /**
+     * @var mixed|null
+     */
+    protected $queries;
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+    /**
+     * @param mixed $name
+     *
+     * @return self
+     */
+    public function setName($name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return mixed
+     */
+    public function getQueries()
+    {
+        return $this->queries;
+    }
+    /**
+     * @param mixed $queries
+     *
+     * @return self
+     */
+    public function setQueries($queries): self
+    {
+        $this->initialized['queries'] = true;
+        $this->queries = $queries;
+        return $this;
+    }
+}

--- a/src/Model/CommonModelsCurationQueryGetResponseGetResponse.php
+++ b/src/Model/CommonModelsCurationQueryGetResponseGetResponse.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class CommonModelsCurationQueryGetResponseGetResponse
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $uuid;
+    /**
+     * @var string
+     */
+    protected $query;
+    /**
+     * @return string
+     */
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+    /**
+     * @param string $uuid
+     *
+     * @return self
+     */
+    public function setUuid(string $uuid): self
+    {
+        $this->initialized['uuid'] = true;
+        $this->uuid = $uuid;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+    /**
+     * @param string $query
+     *
+     * @return self
+     */
+    public function setQuery(string $query): self
+    {
+        $this->initialized['query'] = true;
+        $this->query = $query;
+        return $this;
+    }
+}

--- a/src/Model/CommonModelsCurationQueryPostRequestPostRequest.php
+++ b/src/Model/CommonModelsCurationQueryPostRequestPostRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class CommonModelsCurationQueryPostRequestPostRequest
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $query;
+    /**
+     * @return string
+     */
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+    /**
+     * @param string $query
+     *
+     * @return self
+     */
+    public function setQuery(string $query): self
+    {
+        $this->initialized['query'] = true;
+        $this->query = $query;
+        return $this;
+    }
+}

--- a/src/Model/Coordinate.php
+++ b/src/Model/Coordinate.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class Coordinate extends \ArrayObject
+class Coordinate
 {
     /**
      * @var array

--- a/src/Model/DocumentField.php
+++ b/src/Model/DocumentField.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class DocumentField extends \ArrayObject
+class DocumentField
 {
     /**
      * @var array
@@ -13,11 +13,11 @@ class DocumentField extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $raw;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $snippet;
     /**

--- a/src/Model/DocumentListPagination.php
+++ b/src/Model/DocumentListPagination.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class DocumentListPagination
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * Page number of results to return. Must be greater than or equal to 1.
+     *
+     * @var int
+     */
+    protected $current = 1;
+    /**
+     * Number of results per page. Must be greater than or equal to 1 and less than or equal to 100.
+     *         Defaults to 10.
+     *
+     * @var int
+     */
+    protected $size = 10;
+    /**
+     * Page number of results to return. Must be greater than or equal to 1.
+     *
+     * @return int
+     */
+    public function getCurrent(): int
+    {
+        return $this->current;
+    }
+    /**
+     * Page number of results to return. Must be greater than or equal to 1.
+     *
+     * @param int $current
+     *
+     * @return self
+     */
+    public function setCurrent(int $current): self
+    {
+        $this->initialized['current'] = true;
+        $this->current = $current;
+        return $this;
+    }
+    /**
+     * Number of results per page. Must be greater than or equal to 1 and less than or equal to 100.
+     *         Defaults to 10.
+     *
+     * @return int
+     */
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+    /**
+    * Number of results per page. Must be greater than or equal to 1 and less than or equal to 100. 
+           Defaults to 10.
+    *
+    * @param int $size
+    *
+    * @return self
+    */
+    public function setSize(int $size): self
+    {
+        $this->initialized['size'] = true;
+        $this->size = $size;
+        return $this;
+    }
+}

--- a/src/Model/DocumentListRequest.php
+++ b/src/Model/DocumentListRequest.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class DocumentListRequest extends \ArrayObject
+class DocumentListRequest
 {
     /**
      * @var array
@@ -13,22 +13,22 @@ class DocumentListRequest extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var PaginationNoTotals|null
+     * @var DocumentListPagination|null
      */
     protected $page;
     /**
-     * @return PaginationNoTotals|null
+     * @return DocumentListPagination|null
      */
-    public function getPage(): PaginationNoTotals
+    public function getPage(): ?DocumentListPagination
     {
         return $this->page;
     }
     /**
-     * @param PaginationNoTotals|null $page
+     * @param DocumentListPagination|null $page
      *
      * @return self
      */
-    public function setPage(PaginationNoTotals $page): self
+    public function setPage(?DocumentListPagination $page): self
     {
         $this->initialized['page'] = true;
         $this->page = $page;

--- a/src/Model/DocumentListResponse.php
+++ b/src/Model/DocumentListResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class DocumentListResponse extends \ArrayObject
+class DocumentListResponse
 {
     /**
      * @var array

--- a/src/Model/DocumentListResponseMeta.php
+++ b/src/Model/DocumentListResponseMeta.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class DocumentListResponseMeta extends \ArrayObject
+class DocumentListResponseMeta
 {
     /**
      * @var array
@@ -13,19 +13,19 @@ class DocumentListResponseMeta extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $alerts;
     /**
-     * @var PaginationWithTotals
+     * @var PaginationResponse
      */
     protected $page;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $requestId;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $warnings;
     /**
@@ -47,18 +47,18 @@ class DocumentListResponseMeta extends \ArrayObject
         return $this;
     }
     /**
-     * @return PaginationWithTotals
+     * @return PaginationResponse
      */
-    public function getPage(): PaginationWithTotals
+    public function getPage(): PaginationResponse
     {
         return $this->page;
     }
     /**
-     * @param PaginationWithTotals $page
+     * @param PaginationResponse $page
      *
      * @return self
      */
-    public function setPage(PaginationWithTotals $page): self
+    public function setPage(PaginationResponse $page): self
     {
         $this->initialized['page'] = true;
         $this->page = $page;

--- a/src/Model/DocumentPostPatchResponse.php
+++ b/src/Model/DocumentPostPatchResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class DocumentPostPatchResponse extends \ArrayObject
+class DocumentPostPatchResponse
 {
     /**
      * @var array
@@ -17,7 +17,7 @@ class DocumentPostPatchResponse extends \ArrayObject
      */
     protected $id;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $errors;
     /**

--- a/src/Model/DocumentResponseMeta.php
+++ b/src/Model/DocumentResponseMeta.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class DocumentResponseMeta extends \ArrayObject
+class DocumentResponseMeta
 {
     /**
      * @var array
@@ -13,15 +13,15 @@ class DocumentResponseMeta extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $score;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $engine;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $id;
     /**

--- a/src/Model/DocumentsDeleteResponse.php
+++ b/src/Model/DocumentsDeleteResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class DocumentsDeleteResponse extends \ArrayObject
+class DocumentsDeleteResponse
 {
     /**
      * @var array

--- a/src/Model/EngineName.php
+++ b/src/Model/EngineName.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class Engine extends \ArrayObject
+class EngineName
 {
     /**
      * @var array

--- a/src/Model/EnginesResponse.php
+++ b/src/Model/EnginesResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class EnginesResponse extends \ArrayObject
+class EnginesResponse
 {
     /**
      * @var array
@@ -13,18 +13,18 @@ class EnginesResponse extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var list<Engine>
+     * @var list<EngineName>
      */
     protected $results;
     /**
-     * @return list<Engine>
+     * @return list<EngineName>
      */
     public function getResults(): array
     {
         return $this->results;
     }
     /**
-     * @param list<Engine> $results
+     * @param list<EngineName> $results
      *
      * @return self
      */

--- a/src/Model/FacetResponse.php
+++ b/src/Model/FacetResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class FacetResponse extends \ArrayObject
+class FacetResponse
 {
     /**
      * @var array
@@ -17,11 +17,11 @@ class FacetResponse extends \ArrayObject
      */
     protected $type;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $name;
     /**
-     * @var list<mixed>
+     * @var list<ResponseFacetValue>|list<ResponseFacetRange>
      */
     protected $data;
     /**
@@ -61,14 +61,14 @@ class FacetResponse extends \ArrayObject
         return $this;
     }
     /**
-     * @return list<mixed>
+     * @return list<ResponseFacetValue>|list<ResponseFacetRange>
      */
     public function getData(): array
     {
         return $this->data;
     }
     /**
-     * @param list<mixed> $data
+     * @param list<ResponseFacetValue>|list<ResponseFacetRange> $data
      *
      * @return self
      */

--- a/src/Model/FilterObjectLevel1.php
+++ b/src/Model/FilterObjectLevel1.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class FilterObjectLevel1 extends \ArrayObject
+class FilterObjectLevel1
 {
     /**
      * @var array
@@ -13,15 +13,15 @@ class FilterObjectLevel1 extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $all;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $any;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $none;
     /**

--- a/src/Model/FilterObjectLevel2.php
+++ b/src/Model/FilterObjectLevel2.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class FilterObjectLevel2 extends \ArrayObject
+class FilterObjectLevel2
 {
     /**
      * @var array
@@ -13,15 +13,15 @@ class FilterObjectLevel2 extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $all;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $any;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $none;
     /**

--- a/src/Model/FilterObjectLevel3.php
+++ b/src/Model/FilterObjectLevel3.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class FilterObjectLevel3 extends \ArrayObject
+class FilterObjectLevel3
 {
     /**
      * @var array
@@ -13,15 +13,15 @@ class FilterObjectLevel3 extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $all;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $any;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $none;
     /**

--- a/src/Model/FilterObjectLevel4.php
+++ b/src/Model/FilterObjectLevel4.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class FilterObjectLevel4 extends \ArrayObject
+class FilterObjectLevel4
 {
     /**
      * @var array
@@ -13,15 +13,15 @@ class FilterObjectLevel4 extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $all;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $any;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $none;
     /**

--- a/src/Model/Filters.php
+++ b/src/Model/Filters.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class Filters extends \ArrayObject
+class Filters
 {
     /**
      * @var array
@@ -13,15 +13,15 @@ class Filters extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $all;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $any;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $none;
     /**

--- a/src/Model/Geo.php
+++ b/src/Model/Geo.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class Geo extends \ArrayObject
+class Geo
 {
     /**
      * @var array
@@ -13,11 +13,11 @@ class Geo extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $from;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $to;
     /**
@@ -29,7 +29,7 @@ class Geo extends \ArrayObject
      */
     protected $unit;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $distance;
     /**

--- a/src/Model/Geolocation.php
+++ b/src/Model/Geolocation.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class Geolocation extends \ArrayObject
+class Geolocation
 {
     /**
      * @var array

--- a/src/Model/HTTPValidationError.php
+++ b/src/Model/HTTPValidationError.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class HTTPValidationError extends \ArrayObject
+class HTTPValidationError
 {
     /**
      * @var array

--- a/src/Model/PaginationResponse.php
+++ b/src/Model/PaginationResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class PaginationWithTotals extends \ArrayObject
+class PaginationResponse
 {
     /**
      * @var array

--- a/src/Model/PostResponse.php
+++ b/src/Model/PostResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class PostResponse
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $uuid;
+    /**
+     * @return string
+     */
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+    /**
+     * @param string $uuid
+     *
+     * @return self
+     */
+    public function setUuid(string $uuid): self
+    {
+        $this->initialized['uuid'] = true;
+        $this->uuid = $uuid;
+        return $this;
+    }
+}

--- a/src/Model/QuerySuggestionRequest.php
+++ b/src/Model/QuerySuggestionRequest.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class QuerySuggestionRequest extends \ArrayObject
+class QuerySuggestionRequest
 {
     /**
      * @var array
@@ -13,7 +13,7 @@ class QuerySuggestionRequest extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * A partial query for which to receive suggestions.
+     * A partial query for which to receive suggestions. Maximum length of 128 characters.
      *
      * @var string
      */
@@ -27,11 +27,11 @@ class QuerySuggestionRequest extends \ArrayObject
     /**
      * Specify the document fields to look for suggestions within. Defaults to all text fields.
      *
-     * @var mixed
+     * @var mixed|null
      */
     protected $fields;
     /**
-     * A partial query for which to receive suggestions.
+     * A partial query for which to receive suggestions. Maximum length of 128 characters.
      *
      * @return string
      */
@@ -40,7 +40,7 @@ class QuerySuggestionRequest extends \ArrayObject
         return $this->query;
     }
     /**
-     * A partial query for which to receive suggestions.
+     * A partial query for which to receive suggestions. Maximum length of 128 characters.
      *
      * @param string $query
      *

--- a/src/Model/QuerySuggestionResponse.php
+++ b/src/Model/QuerySuggestionResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class QuerySuggestionResponse extends \ArrayObject
+class QuerySuggestionResponse
 {
     /**
      * @var array

--- a/src/Model/QuerySuggestionResponseValue.php
+++ b/src/Model/QuerySuggestionResponseValue.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class QuerySuggestionResponseValue extends \ArrayObject
+class QuerySuggestionResponseValue
 {
     /**
      * @var array

--- a/src/Model/Range.php
+++ b/src/Model/Range.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class Range extends \ArrayObject
+class Range
 {
     /**
      * @var array
@@ -13,11 +13,11 @@ class Range extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $from;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $to;
     /**

--- a/src/Model/RequestFacetRange.php
+++ b/src/Model/RequestFacetRange.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class RequestFacetRange extends \ArrayObject
+class RequestFacetRange
 {
     /**
      * @var array
@@ -17,7 +17,7 @@ class RequestFacetRange extends \ArrayObject
      */
     protected $type;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $name;
     /**

--- a/src/Model/RequestFacetRangeObject.php
+++ b/src/Model/RequestFacetRangeObject.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class RequestFacetRangeObject extends \ArrayObject
+class RequestFacetRangeObject
 {
     /**
      * @var array
@@ -13,15 +13,15 @@ class RequestFacetRangeObject extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $from;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $to;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $name;
     /**

--- a/src/Model/RequestFacetValue.php
+++ b/src/Model/RequestFacetValue.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class RequestFacetValue extends \ArrayObject
+class RequestFacetValue
 {
     /**
      * @var array
@@ -17,7 +17,7 @@ class RequestFacetValue extends \ArrayObject
      */
     protected $type;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $name;
     /**
@@ -85,7 +85,7 @@ class RequestFacetValue extends \ArrayObject
     /**
      * @return array<string, string>|null
      */
-    public function getSort(): iterable
+    public function getSort(): ?iterable
     {
         return $this->sort;
     }
@@ -94,7 +94,7 @@ class RequestFacetValue extends \ArrayObject
      *
      * @return self
      */
-    public function setSort(iterable $sort): self
+    public function setSort(?iterable $sort): self
     {
         $this->initialized['sort'] = true;
         $this->sort = $sort;

--- a/src/Model/ResponseAcknowledged.php
+++ b/src/Model/ResponseAcknowledged.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SchemaPostResponse extends \ArrayObject
+class ResponseAcknowledged
 {
     /**
      * @var array

--- a/src/Model/ResponseConfirm.php
+++ b/src/Model/ResponseConfirm.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class ResponseConfirm
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $message;
+    /**
+     * @var int
+     */
+    protected $token;
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+    /**
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(string $message): self
+    {
+        $this->initialized['message'] = true;
+        $this->message = $message;
+        return $this;
+    }
+    /**
+     * @return int
+     */
+    public function getToken(): int
+    {
+        return $this->token;
+    }
+    /**
+     * @param int $token
+     *
+     * @return self
+     */
+    public function setToken(int $token): self
+    {
+        $this->initialized['token'] = true;
+        $this->token = $token;
+        return $this;
+    }
+}

--- a/src/Model/ResponseFacetRange.php
+++ b/src/Model/ResponseFacetRange.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class ResponseFacetRange extends \ArrayObject
+class ResponseFacetRange
 {
     /**
      * @var array
@@ -13,15 +13,15 @@ class ResponseFacetRange extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $from;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $to;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $name;
     /**

--- a/src/Model/ResponseFacetValue.php
+++ b/src/Model/ResponseFacetValue.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class ResponseFacetValue extends \ArrayObject
+class ResponseFacetValue
 {
     /**
      * @var array

--- a/src/Model/ResponseSuccess.php
+++ b/src/Model/ResponseSuccess.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class ResponseSuccess extends \ArrayObject
+class ResponseSuccess
 {
     /**
      * @var array

--- a/src/Model/Schema.php
+++ b/src/Model/Schema.php
@@ -13,11 +13,11 @@ class Schema extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $attachment;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $body;
     /**

--- a/src/Model/SchemaGetResponse.php
+++ b/src/Model/SchemaGetResponse.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class SchemaGetResponse extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+}

--- a/src/Model/SearchRequest.php
+++ b/src/Model/SearchRequest.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SearchRequest extends \ArrayObject
+class SearchRequest
 {
     /**
      * @var array
@@ -21,7 +21,7 @@ class SearchRequest extends \ArrayObject
      */
     protected $sort;
     /**
-     * @var PaginationNoTotals|null
+     * @var SearchRequestPagination|null
      */
     protected $page;
     /**
@@ -33,7 +33,7 @@ class SearchRequest extends \ArrayObject
      */
     protected $resultFields;
     /**
-     * @var array<string, list<mixed>>|null
+     * @var array<string, list<RequestFacetValue>|list<RequestFacetRange>>|null
      */
     protected $facets;
     /**
@@ -41,9 +41,17 @@ class SearchRequest extends \ArrayObject
      */
     protected $filters;
     /**
+     * @var mixed|null
+     */
+    protected $boosts;
+    /**
      * @var Tags|null
      */
     protected $analytics;
+    /**
+     * @var bool
+     */
+    protected $recordAnalytics = true;
     /**
      * @return string
      */
@@ -81,18 +89,18 @@ class SearchRequest extends \ArrayObject
         return $this;
     }
     /**
-     * @return PaginationNoTotals|null
+     * @return SearchRequestPagination|null
      */
-    public function getPage(): PaginationNoTotals
+    public function getPage(): ?SearchRequestPagination
     {
         return $this->page;
     }
     /**
-     * @param PaginationNoTotals|null $page
+     * @param SearchRequestPagination|null $page
      *
      * @return self
      */
-    public function setPage(PaginationNoTotals $page): self
+    public function setPage(?SearchRequestPagination $page): self
     {
         $this->initialized['page'] = true;
         $this->page = $page;
@@ -119,7 +127,7 @@ class SearchRequest extends \ArrayObject
     /**
      * @return array<string, SearchRequestResultField>|null
      */
-    public function getResultFields(): iterable
+    public function getResultFields(): ?iterable
     {
         return $this->resultFields;
     }
@@ -128,25 +136,25 @@ class SearchRequest extends \ArrayObject
      *
      * @return self
      */
-    public function setResultFields(iterable $resultFields): self
+    public function setResultFields(?iterable $resultFields): self
     {
         $this->initialized['resultFields'] = true;
         $this->resultFields = $resultFields;
         return $this;
     }
     /**
-     * @return array<string, list<mixed>>|null
+     * @return array<string, list<RequestFacetValue>|list<RequestFacetRange>>|null
      */
-    public function getFacets(): iterable
+    public function getFacets(): ?iterable
     {
         return $this->facets;
     }
     /**
-     * @param array<string, list<mixed>>|null $facets
+     * @param array<string, list<RequestFacetValue>|list<RequestFacetRange>>|null $facets
      *
      * @return self
      */
-    public function setFacets(iterable $facets): self
+    public function setFacets(?iterable $facets): self
     {
         $this->initialized['facets'] = true;
         $this->facets = $facets;
@@ -155,7 +163,7 @@ class SearchRequest extends \ArrayObject
     /**
      * @return Filters|null
      */
-    public function getFilters(): Filters
+    public function getFilters(): ?Filters
     {
         return $this->filters;
     }
@@ -164,16 +172,34 @@ class SearchRequest extends \ArrayObject
      *
      * @return self
      */
-    public function setFilters(Filters $filters): self
+    public function setFilters(?Filters $filters): self
     {
         $this->initialized['filters'] = true;
         $this->filters = $filters;
         return $this;
     }
     /**
+     * @return mixed
+     */
+    public function getBoosts()
+    {
+        return $this->boosts;
+    }
+    /**
+     * @param mixed $boosts
+     *
+     * @return self
+     */
+    public function setBoosts($boosts): self
+    {
+        $this->initialized['boosts'] = true;
+        $this->boosts = $boosts;
+        return $this;
+    }
+    /**
      * @return Tags|null
      */
-    public function getAnalytics(): Tags
+    public function getAnalytics(): ?Tags
     {
         return $this->analytics;
     }
@@ -182,10 +208,28 @@ class SearchRequest extends \ArrayObject
      *
      * @return self
      */
-    public function setAnalytics(Tags $analytics): self
+    public function setAnalytics(?Tags $analytics): self
     {
         $this->initialized['analytics'] = true;
         $this->analytics = $analytics;
+        return $this;
+    }
+    /**
+     * @return bool
+     */
+    public function getRecordAnalytics(): bool
+    {
+        return $this->recordAnalytics;
+    }
+    /**
+     * @param bool $recordAnalytics
+     *
+     * @return self
+     */
+    public function setRecordAnalytics(bool $recordAnalytics): self
+    {
+        $this->initialized['recordAnalytics'] = true;
+        $this->recordAnalytics = $recordAnalytics;
         return $this;
     }
 }

--- a/src/Model/SearchRequestBoost.php
+++ b/src/Model/SearchRequestBoost.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Silverstripe\Search\Client\Model;
+
+class SearchRequestBoost
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * Types of boosts that can be applied to fields.
+     * 
+     * Valid combinations:
+     * - text: value
+     * - number: value, proximity, functional
+     * - date: value, proximity
+     * - geolocation: proximity
+     *
+     * @var string
+     */
+    protected $type;
+    /**
+     * Values to boost on. Required for value boosts.
+     *
+     * @var mixed|null
+     */
+    protected $value;
+    /**
+     * Boost factor/impact (0-10). Defaults to 1.
+     *
+     * @var float
+     */
+    protected $factor = 1.0;
+    /**
+     * Center point for proximity boosts.
+     *
+     * @var mixed|null
+     */
+    protected $center;
+    /**
+     * Function for proximity (gaussian, exponential, linear) or functional (logarithmic, exponential, linear) boosts.
+     *
+     * @var mixed|null
+     */
+    protected $function;
+    /**
+     * How to combine function result with score (multiply, add). For functional boosts.
+     *
+     * @var string|null
+     */
+    protected $operation;
+    /**
+     * Types of boosts that can be applied to fields.
+     * 
+     * Valid combinations:
+     * - text: value
+     * - number: value, proximity, functional
+     * - date: value, proximity
+     * - geolocation: proximity
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+    /**
+    * Types of boosts that can be applied to fields.
+    
+    Valid combinations:
+    - text: value
+    - number: value, proximity, functional
+    - date: value, proximity
+    - geolocation: proximity
+    *
+    * @param string $type
+    *
+    * @return self
+    */
+    public function setType(string $type): self
+    {
+        $this->initialized['type'] = true;
+        $this->type = $type;
+        return $this;
+    }
+    /**
+     * Values to boost on. Required for value boosts.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+    /**
+     * Values to boost on. Required for value boosts.
+     *
+     * @param mixed $value
+     *
+     * @return self
+     */
+    public function setValue($value): self
+    {
+        $this->initialized['value'] = true;
+        $this->value = $value;
+        return $this;
+    }
+    /**
+     * Boost factor/impact (0-10). Defaults to 1.
+     *
+     * @return float
+     */
+    public function getFactor(): float
+    {
+        return $this->factor;
+    }
+    /**
+     * Boost factor/impact (0-10). Defaults to 1.
+     *
+     * @param float $factor
+     *
+     * @return self
+     */
+    public function setFactor(float $factor): self
+    {
+        $this->initialized['factor'] = true;
+        $this->factor = $factor;
+        return $this;
+    }
+    /**
+     * Center point for proximity boosts.
+     *
+     * @return mixed
+     */
+    public function getCenter()
+    {
+        return $this->center;
+    }
+    /**
+     * Center point for proximity boosts.
+     *
+     * @param mixed $center
+     *
+     * @return self
+     */
+    public function setCenter($center): self
+    {
+        $this->initialized['center'] = true;
+        $this->center = $center;
+        return $this;
+    }
+    /**
+     * Function for proximity (gaussian, exponential, linear) or functional (logarithmic, exponential, linear) boosts.
+     *
+     * @return mixed
+     */
+    public function getFunction()
+    {
+        return $this->function;
+    }
+    /**
+     * Function for proximity (gaussian, exponential, linear) or functional (logarithmic, exponential, linear) boosts.
+     *
+     * @param mixed $function
+     *
+     * @return self
+     */
+    public function setFunction($function): self
+    {
+        $this->initialized['function'] = true;
+        $this->function = $function;
+        return $this;
+    }
+    /**
+     * How to combine function result with score (multiply, add). For functional boosts.
+     *
+     * @return string|null
+     */
+    public function getOperation(): ?string
+    {
+        return $this->operation;
+    }
+    /**
+     * How to combine function result with score (multiply, add). For functional boosts.
+     *
+     * @param string|null $operation
+     *
+     * @return self
+     */
+    public function setOperation(?string $operation): self
+    {
+        $this->initialized['operation'] = true;
+        $this->operation = $operation;
+        return $this;
+    }
+}

--- a/src/Model/SearchRequestPagination.php
+++ b/src/Model/SearchRequestPagination.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class PaginationNoTotals extends \ArrayObject
+class SearchRequestPagination
 {
     /**
      * @var array

--- a/src/Model/SearchRequestResultField.php
+++ b/src/Model/SearchRequestResultField.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SearchRequestResultField extends \ArrayObject
+class SearchRequestResultField
 {
     /**
      * @var array
@@ -25,7 +25,7 @@ class SearchRequestResultField extends \ArrayObject
     /**
      * @return SearchRequestResultFieldRaw|null
      */
-    public function getRaw(): SearchRequestResultFieldRaw
+    public function getRaw(): ?SearchRequestResultFieldRaw
     {
         return $this->raw;
     }
@@ -34,7 +34,7 @@ class SearchRequestResultField extends \ArrayObject
      *
      * @return self
      */
-    public function setRaw(SearchRequestResultFieldRaw $raw): self
+    public function setRaw(?SearchRequestResultFieldRaw $raw): self
     {
         $this->initialized['raw'] = true;
         $this->raw = $raw;
@@ -45,7 +45,7 @@ class SearchRequestResultField extends \ArrayObject
      *
      * @return SearchRequestResultFieldSnippet|null
      */
-    public function getSnippet(): SearchRequestResultFieldSnippet
+    public function getSnippet(): ?SearchRequestResultFieldSnippet
     {
         return $this->snippet;
     }
@@ -56,7 +56,7 @@ class SearchRequestResultField extends \ArrayObject
      *
      * @return self
      */
-    public function setSnippet(SearchRequestResultFieldSnippet $snippet): self
+    public function setSnippet(?SearchRequestResultFieldSnippet $snippet): self
     {
         $this->initialized['snippet'] = true;
         $this->snippet = $snippet;

--- a/src/Model/SearchRequestResultFieldRaw.php
+++ b/src/Model/SearchRequestResultFieldRaw.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SearchRequestResultFieldRaw extends \ArrayObject
+class SearchRequestResultFieldRaw
 {
     /**
      * @var array
@@ -16,7 +16,7 @@ class SearchRequestResultFieldRaw extends \ArrayObject
      * Length of the return value (to the nearest word). Can only be used on text fields. If given for
      *         a field type other than text, it will be silently ignored. Defaults to the entire text field.
      *
-     * @var mixed
+     * @var mixed|null
      */
     protected $size;
     /**

--- a/src/Model/SearchRequestResultFieldSnippet.php
+++ b/src/Model/SearchRequestResultFieldSnippet.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SearchRequestResultFieldSnippet extends \ArrayObject
+class SearchRequestResultFieldSnippet
 {
     /**
      * @var array
@@ -16,13 +16,13 @@ class SearchRequestResultFieldSnippet extends \ArrayObject
      * Character length of the snippet returned (to the nearest word). Must be at least 20; defaults to
      *         100.
      *
-     * @var mixed
+     * @var mixed|null
      */
     protected $size = 100;
     /**
      * If true, return the raw text field as the snippet (if no snippet is found). Defaults to true.
      *
-     * @var mixed
+     * @var mixed|null
      */
     protected $fallback = true;
     /**

--- a/src/Model/SearchRequestSearchFieldsWeight.php
+++ b/src/Model/SearchRequestSearchFieldsWeight.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SearchRequestSearchFieldsWeight extends \ArrayObject
+class SearchRequestSearchFieldsWeight
 {
     /**
      * @var array
@@ -13,7 +13,7 @@ class SearchRequestSearchFieldsWeight extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $weight;
     /**

--- a/src/Model/SearchResponse.php
+++ b/src/Model/SearchResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SearchResponse extends \ArrayObject
+class SearchResponse
 {
     /**
      * @var array
@@ -17,11 +17,11 @@ class SearchResponse extends \ArrayObject
      */
     protected $meta;
     /**
-     * @var list<array<string, mixed>>
+     * @var list<array<string, DocumentResponseMeta|DocumentField>>
      */
     protected $results;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $facets;
     /**
@@ -43,14 +43,14 @@ class SearchResponse extends \ArrayObject
         return $this;
     }
     /**
-     * @return list<array<string, mixed>>
+     * @return list<array<string, DocumentResponseMeta|DocumentField>>
      */
     public function getResults(): array
     {
         return $this->results;
     }
     /**
-     * @param list<array<string, mixed>> $results
+     * @param list<array<string, DocumentResponseMeta|DocumentField>> $results
      *
      * @return self
      */

--- a/src/Model/SearchResponseEngine.php
+++ b/src/Model/SearchResponseEngine.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SearchResponseEngine extends \ArrayObject
+class SearchResponseEngine
 {
     /**
      * @var array
@@ -13,11 +13,11 @@ class SearchResponseEngine extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $name;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $type;
     /**

--- a/src/Model/SearchResponseMeta.php
+++ b/src/Model/SearchResponseMeta.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SearchResponseMeta extends \ArrayObject
+class SearchResponseMeta
 {
     /**
      * @var array
@@ -13,11 +13,11 @@ class SearchResponseMeta extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $warnings;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $precision;
     /**
@@ -25,11 +25,11 @@ class SearchResponseMeta extends \ArrayObject
      */
     protected $engine;
     /**
-     * @var mixed
+     * @var mixed|null
      */
     protected $requestId;
     /**
-     * @var PaginationWithTotals
+     * @var PaginationResponse
      */
     protected $page;
     /**
@@ -71,7 +71,7 @@ class SearchResponseMeta extends \ArrayObject
     /**
      * @return SearchResponseEngine|null
      */
-    public function getEngine(): SearchResponseEngine
+    public function getEngine(): ?SearchResponseEngine
     {
         return $this->engine;
     }
@@ -80,7 +80,7 @@ class SearchResponseMeta extends \ArrayObject
      *
      * @return self
      */
-    public function setEngine(SearchResponseEngine $engine): self
+    public function setEngine(?SearchResponseEngine $engine): self
     {
         $this->initialized['engine'] = true;
         $this->engine = $engine;
@@ -105,18 +105,18 @@ class SearchResponseMeta extends \ArrayObject
         return $this;
     }
     /**
-     * @return PaginationWithTotals
+     * @return PaginationResponse
      */
-    public function getPage(): PaginationWithTotals
+    public function getPage(): PaginationResponse
     {
         return $this->page;
     }
     /**
-     * @param PaginationWithTotals $page
+     * @param PaginationResponse $page
      *
      * @return self
      */
-    public function setPage(PaginationWithTotals $page): self
+    public function setPage(PaginationResponse $page): self
     {
         $this->initialized['page'] = true;
         $this->page = $page;

--- a/src/Model/SettingsRequest.php
+++ b/src/Model/SettingsRequest.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SettingsRequest extends \ArrayObject
+class SettingsRequest
 {
     /**
      * @var array

--- a/src/Model/SettingsResponse.php
+++ b/src/Model/SettingsResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SettingsResponse extends \ArrayObject
+class SettingsResponse
 {
     /**
      * @var array

--- a/src/Model/SpellingSuggestionRequest.php
+++ b/src/Model/SpellingSuggestionRequest.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SpellingSuggestionRequest extends \ArrayObject
+class SpellingSuggestionRequest
 {
     /**
      * @var array
@@ -13,7 +13,7 @@ class SpellingSuggestionRequest extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * A query for which to receive spelling suggestions.
+     * A query for which to receive spelling suggestions. Maximum length of 128 characters.
      *
      * @var string
      */
@@ -31,11 +31,11 @@ class SpellingSuggestionRequest extends \ArrayObject
     /**
      * Whether you would like a 'snippet' field to be returned with each of your results.
      *
-     * @var mixed
+     * @var mixed|null
      */
     protected $formatted = false;
     /**
-     * A query for which to receive spelling suggestions.
+     * A query for which to receive spelling suggestions. Maximum length of 128 characters.
      *
      * @return string
      */
@@ -44,7 +44,7 @@ class SpellingSuggestionRequest extends \ArrayObject
         return $this->query;
     }
     /**
-     * A query for which to receive spelling suggestions.
+     * A query for which to receive spelling suggestions. Maximum length of 128 characters.
      *
      * @param string $query
      *

--- a/src/Model/SpellingSuggestionResponse.php
+++ b/src/Model/SpellingSuggestionResponse.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SpellingSuggestionResponse extends \ArrayObject
+class SpellingSuggestionResponse
 {
     /**
      * @var array

--- a/src/Model/SynonymRule.php
+++ b/src/Model/SynonymRule.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SynonymRule extends \ArrayObject
+class SynonymRule
 {
     /**
      * @var array

--- a/src/Model/SynonymRuleRequest.php
+++ b/src/Model/SynonymRuleRequest.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class SynonymRuleRequest extends \ArrayObject
+class SynonymRuleRequest
 {
     /**
      * @var array

--- a/src/Model/Tags.php
+++ b/src/Model/Tags.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class Tags extends \ArrayObject
+class Tags
 {
     /**
      * @var array

--- a/src/Model/ValidationError.php
+++ b/src/Model/ValidationError.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\Search\Client\Model;
 
-class ValidationError extends \ArrayObject
+class ValidationError
 {
     /**
      * @var array

--- a/src/Normalizer/BoostGetResponseNormalizer.php
+++ b/src/Normalizer/BoostGetResponseNormalizer.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class BoostGetResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\BoostGetResponse::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\BoostGetResponse::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\BoostGetResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('impact', $data) && \is_int($data['impact'])) {
+            $data['impact'] = (double) $data['impact'];
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+        }
+        if (\array_key_exists('type', $data)) {
+            $object->setType($data['type']);
+        }
+        if (\array_key_exists('impact', $data)) {
+            $object->setImpact($data['impact']);
+        }
+        if (\array_key_exists('values', $data) && $data['values'] !== null) {
+            $object->setValues($data['values']);
+        }
+        elseif (\array_key_exists('values', $data) && $data['values'] === null) {
+            $object->setValues(null);
+        }
+        if (\array_key_exists('center', $data) && $data['center'] !== null) {
+            $object->setCenter($data['center']);
+        }
+        elseif (\array_key_exists('center', $data) && $data['center'] === null) {
+            $object->setCenter(null);
+        }
+        if (\array_key_exists('function', $data) && $data['function'] !== null) {
+            $object->setFunction($data['function']);
+        }
+        elseif (\array_key_exists('function', $data) && $data['function'] === null) {
+            $object->setFunction(null);
+        }
+        if (\array_key_exists('operation', $data) && $data['operation'] !== null) {
+            $value = $data['operation'];
+            if (is_string($data['operation'])) {
+                $value = $data['operation'];
+            } elseif (is_null($data['operation'])) {
+                $value = $data['operation'];
+            }
+            $object->setOperation($value);
+        }
+        elseif (\array_key_exists('operation', $data) && $data['operation'] === null) {
+            $object->setOperation(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['id'] = $data->getId();
+        $dataArray['type'] = $data->getType();
+        $dataArray['impact'] = $data->getImpact();
+        if ($data->isInitialized('values')) {
+            $dataArray['values'] = $data->getValues();
+        }
+        if ($data->isInitialized('center')) {
+            $dataArray['center'] = $data->getCenter();
+        }
+        if ($data->isInitialized('function')) {
+            $dataArray['function'] = $data->getFunction();
+        }
+        if ($data->isInitialized('operation')) {
+            $value = $data->getOperation();
+            if (is_string($data->getOperation())) {
+                $value = $data->getOperation();
+            } elseif (is_null($data->getOperation())) {
+                $value = $data->getOperation();
+            }
+            $dataArray['operation'] = $value;
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\BoostGetResponse::class => false];
+    }
+}

--- a/src/Normalizer/BoostPatchRequestNormalizer.php
+++ b/src/Normalizer/BoostPatchRequestNormalizer.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class BoostPatchRequestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\BoostPatchRequest::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\BoostPatchRequest::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\BoostPatchRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('impact', $data) && $data['impact'] !== null) {
+            $object->setImpact($data['impact']);
+        }
+        elseif (\array_key_exists('impact', $data) && $data['impact'] === null) {
+            $object->setImpact(null);
+        }
+        if (\array_key_exists('values', $data) && $data['values'] !== null) {
+            $object->setValues($data['values']);
+        }
+        elseif (\array_key_exists('values', $data) && $data['values'] === null) {
+            $object->setValues(null);
+        }
+        if (\array_key_exists('center', $data) && $data['center'] !== null) {
+            $object->setCenter($data['center']);
+        }
+        elseif (\array_key_exists('center', $data) && $data['center'] === null) {
+            $object->setCenter(null);
+        }
+        if (\array_key_exists('function', $data) && $data['function'] !== null) {
+            $object->setFunction($data['function']);
+        }
+        elseif (\array_key_exists('function', $data) && $data['function'] === null) {
+            $object->setFunction(null);
+        }
+        if (\array_key_exists('operation', $data) && $data['operation'] !== null) {
+            $value = $data['operation'];
+            if (is_string($data['operation'])) {
+                $value = $data['operation'];
+            } elseif (is_null($data['operation'])) {
+                $value = $data['operation'];
+            }
+            $object->setOperation($value);
+        }
+        elseif (\array_key_exists('operation', $data) && $data['operation'] === null) {
+            $object->setOperation(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('impact')) {
+            $dataArray['impact'] = $data->getImpact();
+        }
+        if ($data->isInitialized('values')) {
+            $dataArray['values'] = $data->getValues();
+        }
+        if ($data->isInitialized('center')) {
+            $dataArray['center'] = $data->getCenter();
+        }
+        if ($data->isInitialized('function')) {
+            $dataArray['function'] = $data->getFunction();
+        }
+        if ($data->isInitialized('operation')) {
+            $value = $data->getOperation();
+            if (is_string($data->getOperation())) {
+                $value = $data->getOperation();
+            } elseif (is_null($data->getOperation())) {
+                $value = $data->getOperation();
+            }
+            $dataArray['operation'] = $value;
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\BoostPatchRequest::class => false];
+    }
+}

--- a/src/Normalizer/BoostPostRequestNormalizer.php
+++ b/src/Normalizer/BoostPostRequestNormalizer.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class BoostPostRequestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\BoostPostRequest::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\BoostPostRequest::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\BoostPostRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('impact', $data) && \is_int($data['impact'])) {
+            $data['impact'] = (double) $data['impact'];
+        }
+        if (\array_key_exists('type', $data)) {
+            $object->setType($data['type']);
+        }
+        if (\array_key_exists('impact', $data)) {
+            $object->setImpact($data['impact']);
+        }
+        if (\array_key_exists('values', $data) && $data['values'] !== null) {
+            $object->setValues($data['values']);
+        }
+        elseif (\array_key_exists('values', $data) && $data['values'] === null) {
+            $object->setValues(null);
+        }
+        if (\array_key_exists('center', $data) && $data['center'] !== null) {
+            $object->setCenter($data['center']);
+        }
+        elseif (\array_key_exists('center', $data) && $data['center'] === null) {
+            $object->setCenter(null);
+        }
+        if (\array_key_exists('function', $data) && $data['function'] !== null) {
+            $object->setFunction($data['function']);
+        }
+        elseif (\array_key_exists('function', $data) && $data['function'] === null) {
+            $object->setFunction(null);
+        }
+        if (\array_key_exists('operation', $data) && $data['operation'] !== null) {
+            $value = $data['operation'];
+            if (is_string($data['operation'])) {
+                $value = $data['operation'];
+            } elseif (is_null($data['operation'])) {
+                $value = $data['operation'];
+            }
+            $object->setOperation($value);
+        }
+        elseif (\array_key_exists('operation', $data) && $data['operation'] === null) {
+            $object->setOperation(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['type'] = $data->getType();
+        $dataArray['impact'] = $data->getImpact();
+        if ($data->isInitialized('values')) {
+            $dataArray['values'] = $data->getValues();
+        }
+        if ($data->isInitialized('center')) {
+            $dataArray['center'] = $data->getCenter();
+        }
+        if ($data->isInitialized('function')) {
+            $dataArray['function'] = $data->getFunction();
+        }
+        if ($data->isInitialized('operation')) {
+            $value = $data->getOperation();
+            if (is_string($data->getOperation())) {
+                $value = $data->getOperation();
+            } elseif (is_null($data->getOperation())) {
+                $value = $data->getOperation();
+            }
+            $dataArray['operation'] = $value;
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\BoostPostRequest::class => false];
+    }
+}

--- a/src/Normalizer/BoostPostResponseNormalizer.php
+++ b/src/Normalizer/BoostPostResponseNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class BoostPostResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\BoostPostResponse::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\BoostPostResponse::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\BoostPostResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['id'] = $data->getId();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\BoostPostResponse::class => false];
+    }
+}

--- a/src/Normalizer/ClickRequestNormalizer.php
+++ b/src/Normalizer/ClickRequestNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ClickRequestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\ClickRequest::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\ClickRequest::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\ClickRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('request_id', $data)) {
+            $object->setRequestId($data['request_id']);
+        }
+        if (\array_key_exists('document_id', $data)) {
+            $object->setDocumentId($data['document_id']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['request_id'] = $data->getRequestId();
+        $dataArray['document_id'] = $data->getDocumentId();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\ClickRequest::class => false];
+    }
+}

--- a/src/Normalizer/CommonModelsCurationDocumentGetResponseGetResponseNormalizer.php
+++ b/src/Normalizer/CommonModelsCurationDocumentGetResponseGetResponseNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CommonModelsCurationDocumentGetResponseGetResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('document_id', $data)) {
+            $object->setDocumentId($data['document_id']);
+        }
+        if (\array_key_exists('type', $data)) {
+            $object->setType($data['type']);
+        }
+        if (\array_key_exists('sort', $data)) {
+            $object->setSort($data['sort']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['document_id'] = $data->getDocumentId();
+        $dataArray['type'] = $data->getType();
+        $dataArray['sort'] = $data->getSort();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse::class => false];
+    }
+}

--- a/src/Normalizer/CommonModelsCurationDocumentPatchRequestPatchRequestNormalizer.php
+++ b/src/Normalizer/CommonModelsCurationDocumentPatchRequestPatchRequestNormalizer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CommonModelsCurationDocumentPatchRequestPatchRequestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('type', $data) && $data['type'] !== null) {
+            $object->setType($data['type']);
+        }
+        elseif (\array_key_exists('type', $data) && $data['type'] === null) {
+            $object->setType(null);
+        }
+        if (\array_key_exists('sort', $data) && $data['sort'] !== null) {
+            $object->setSort($data['sort']);
+        }
+        elseif (\array_key_exists('sort', $data) && $data['sort'] === null) {
+            $object->setSort(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('type')) {
+            $dataArray['type'] = $data->getType();
+        }
+        if ($data->isInitialized('sort')) {
+            $dataArray['sort'] = $data->getSort();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest::class => false];
+    }
+}

--- a/src/Normalizer/CommonModelsCurationDocumentPostRequestPostRequestNormalizer.php
+++ b/src/Normalizer/CommonModelsCurationDocumentPostRequestPostRequestNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CommonModelsCurationDocumentPostRequestPostRequestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('document_id', $data)) {
+            $object->setDocumentId($data['document_id']);
+        }
+        if (\array_key_exists('type', $data)) {
+            $object->setType($data['type']);
+        }
+        if (\array_key_exists('sort', $data)) {
+            $object->setSort($data['sort']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['document_id'] = $data->getDocumentId();
+        $dataArray['type'] = $data->getType();
+        $dataArray['sort'] = $data->getSort();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest::class => false];
+    }
+}

--- a/src/Normalizer/CommonModelsCurationGetResponseGetResponseNormalizer.php
+++ b/src/Normalizer/CommonModelsCurationGetResponseGetResponseNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class EngineNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class CommonModelsCurationGetResponseGetResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,48 +19,55 @@ class EngineNormalizer implements DenormalizerInterface, NormalizerInterface, De
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Silverstripe\Search\Client\Model\Engine::class;
+        return $type === \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\Engine::class;
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\Engine();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
+        if (\array_key_exists('uuid', $data)) {
+            $object->setUuid($data['uuid']);
         }
-        if (\array_key_exists('name', $data)) {
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
             $object->setName($data['name']);
-            unset($data['name']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
+        }
+        if (\array_key_exists('queries', $data) && $data['queries'] !== null) {
+            $object->setQueries($data['queries']);
+        }
+        elseif (\array_key_exists('queries', $data) && $data['queries'] === null) {
+            $object->setQueries(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        $dataArray['name'] = $data->getName();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
+        $dataArray['uuid'] = $data->getUuid();
+        if ($data->isInitialized('name')) {
+            $dataArray['name'] = $data->getName();
+        }
+        if ($data->isInitialized('queries')) {
+            $dataArray['queries'] = $data->getQueries();
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Silverstripe\Search\Client\Model\Engine::class => false];
+        return [\Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse::class => false];
     }
 }

--- a/src/Normalizer/CommonModelsCurationPatchRequestPatchRequestNormalizer.php
+++ b/src/Normalizer/CommonModelsCurationPatchRequestPatchRequestNormalizer.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CommonModelsCurationPatchRequestPatchRequestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
+            $object->setName($data['name']);
+        }
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('name')) {
+            $dataArray['name'] = $data->getName();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest::class => false];
+    }
+}

--- a/src/Normalizer/CommonModelsCurationPostRequestPostRequestNormalizer.php
+++ b/src/Normalizer/CommonModelsCurationPostRequestPostRequestNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class PaginationNoTotalsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class CommonModelsCurationPostRequestPostRequestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,57 +19,51 @@ class PaginationNoTotalsNormalizer implements DenormalizerInterface, NormalizerI
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Silverstripe\Search\Client\Model\PaginationNoTotals::class;
+        return $type === \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\PaginationNoTotals::class;
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\PaginationNoTotals();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
+            $object->setName($data['name']);
         }
-        if (\array_key_exists('current', $data)) {
-            $object->setCurrent($data['current']);
-            unset($data['current']);
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
         }
-        if (\array_key_exists('size', $data)) {
-            $object->setSize($data['size']);
-            unset($data['size']);
+        if (\array_key_exists('queries', $data) && $data['queries'] !== null) {
+            $object->setQueries($data['queries']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('queries', $data) && $data['queries'] === null) {
+            $object->setQueries(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('current') && null !== $data->getCurrent()) {
-            $dataArray['current'] = $data->getCurrent();
+        if ($data->isInitialized('name')) {
+            $dataArray['name'] = $data->getName();
         }
-        if ($data->isInitialized('size') && null !== $data->getSize()) {
-            $dataArray['size'] = $data->getSize();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
+        if ($data->isInitialized('queries')) {
+            $dataArray['queries'] = $data->getQueries();
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Silverstripe\Search\Client\Model\PaginationNoTotals::class => false];
+        return [\Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest::class => false];
     }
 }

--- a/src/Normalizer/CommonModelsCurationQueryGetResponseGetResponseNormalizer.php
+++ b/src/Normalizer/CommonModelsCurationQueryGetResponseGetResponseNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CommonModelsCurationQueryGetResponseGetResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('uuid', $data)) {
+            $object->setUuid($data['uuid']);
+        }
+        if (\array_key_exists('query', $data)) {
+            $object->setQuery($data['query']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['uuid'] = $data->getUuid();
+        $dataArray['query'] = $data->getQuery();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse::class => false];
+    }
+}

--- a/src/Normalizer/CommonModelsCurationQueryPostRequestPostRequestNormalizer.php
+++ b/src/Normalizer/CommonModelsCurationQueryPostRequestPostRequestNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CommonModelsCurationQueryPostRequestPostRequestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('query', $data)) {
+            $object->setQuery($data['query']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['query'] = $data->getQuery();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest::class => false];
+    }
+}

--- a/src/Normalizer/CoordinateNormalizer.php
+++ b/src/Normalizer/CoordinateNormalizer.php
@@ -27,28 +27,21 @@ class CoordinateNormalizer implements DenormalizerInterface, NormalizerInterface
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\Coordinate();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\Coordinate();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('latitude', $data)) {
             $object->setLatitude($data['latitude']);
-            unset($data['latitude']);
         }
         if (\array_key_exists('longitude', $data)) {
             $object->setLongitude($data['longitude']);
-            unset($data['longitude']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -57,11 +50,6 @@ class CoordinateNormalizer implements DenormalizerInterface, NormalizerInterface
         $dataArray = [];
         $dataArray['latitude'] = $data->getLatitude();
         $dataArray['longitude'] = $data->getLongitude();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/DocumentFieldNormalizer.php
+++ b/src/Normalizer/DocumentFieldNormalizer.php
@@ -27,44 +27,38 @@ class DocumentFieldNormalizer implements DenormalizerInterface, NormalizerInterf
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\DocumentField();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\DocumentField();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('raw', $data)) {
+        if (\array_key_exists('raw', $data) && $data['raw'] !== null) {
             $object->setRaw($data['raw']);
-            unset($data['raw']);
         }
-        if (\array_key_exists('snippet', $data)) {
+        elseif (\array_key_exists('raw', $data) && $data['raw'] === null) {
+            $object->setRaw(null);
+        }
+        if (\array_key_exists('snippet', $data) && $data['snippet'] !== null) {
             $object->setSnippet($data['snippet']);
-            unset($data['snippet']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('snippet', $data) && $data['snippet'] === null) {
+            $object->setSnippet(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('raw') && null !== $data->getRaw()) {
+        if ($data->isInitialized('raw')) {
             $dataArray['raw'] = $data->getRaw();
         }
-        if ($data->isInitialized('snippet') && null !== $data->getSnippet()) {
+        if ($data->isInitialized('snippet')) {
             $dataArray['snippet'] = $data->getSnippet();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/DocumentListPaginationNormalizer.php
+++ b/src/Normalizer/DocumentListPaginationNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class DocumentListPaginationNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\DocumentListPagination::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\DocumentListPagination::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\DocumentListPagination();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('current', $data)) {
+            $object->setCurrent($data['current']);
+        }
+        if (\array_key_exists('size', $data)) {
+            $object->setSize($data['size']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('current') && null !== $data->getCurrent()) {
+            $dataArray['current'] = $data->getCurrent();
+        }
+        if ($data->isInitialized('size') && null !== $data->getSize()) {
+            $dataArray['size'] = $data->getSize();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\DocumentListPagination::class => false];
+    }
+}

--- a/src/Normalizer/DocumentListRequestNormalizer.php
+++ b/src/Normalizer/DocumentListRequestNormalizer.php
@@ -27,49 +27,41 @@ class DocumentListRequestNormalizer implements DenormalizerInterface, Normalizer
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\DocumentListRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\DocumentListRequest();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('page', $data)) {
+        if (\array_key_exists('page', $data) && $data['page'] !== null) {
             $value = $data['page'];
             if (is_array($data['page'])) {
-                $value = $this->denormalizer->denormalize($data['page'], \Silverstripe\Search\Client\Model\PaginationNoTotals::class, 'json', $context);
+                $value = $this->denormalizer->denormalize($data['page'], \Silverstripe\Search\Client\Model\DocumentListPagination::class, 'json', $context);
             } elseif (is_null($data['page'])) {
                 $value = $data['page'];
             }
             $object->setPage($value);
-            unset($data['page']);
         }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
+        elseif (\array_key_exists('page', $data) && $data['page'] === null) {
+            $object->setPage(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('page') && null !== $data->getPage()) {
+        if ($data->isInitialized('page')) {
             $value = $data->getPage();
             if (is_object($data->getPage())) {
-                $value = $data->getPage() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getPage(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                $value = $this->normalizer->normalize($data->getPage(), 'json', $context);
             } elseif (is_null($data->getPage())) {
                 $value = $data->getPage();
             }
             $dataArray['page'] = $value;
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/DocumentListResponseMetaNormalizer.php
+++ b/src/Normalizer/DocumentListResponseMetaNormalizer.php
@@ -27,56 +27,51 @@ class DocumentListResponseMetaNormalizer implements DenormalizerInterface, Norma
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\DocumentListResponseMeta();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\DocumentListResponseMeta();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('alerts', $data)) {
+        if (\array_key_exists('alerts', $data) && $data['alerts'] !== null) {
             $object->setAlerts($data['alerts']);
-            unset($data['alerts']);
+        }
+        elseif (\array_key_exists('alerts', $data) && $data['alerts'] === null) {
+            $object->setAlerts(null);
         }
         if (\array_key_exists('page', $data)) {
-            $object->setPage($this->denormalizer->denormalize($data['page'], \Silverstripe\Search\Client\Model\PaginationWithTotals::class, 'json', $context));
-            unset($data['page']);
+            $object->setPage($this->denormalizer->denormalize($data['page'], \Silverstripe\Search\Client\Model\PaginationResponse::class, 'json', $context));
         }
-        if (\array_key_exists('request_id', $data)) {
+        if (\array_key_exists('request_id', $data) && $data['request_id'] !== null) {
             $object->setRequestId($data['request_id']);
-            unset($data['request_id']);
         }
-        if (\array_key_exists('warnings', $data)) {
+        elseif (\array_key_exists('request_id', $data) && $data['request_id'] === null) {
+            $object->setRequestId(null);
+        }
+        if (\array_key_exists('warnings', $data) && $data['warnings'] !== null) {
             $object->setWarnings($data['warnings']);
-            unset($data['warnings']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('warnings', $data) && $data['warnings'] === null) {
+            $object->setWarnings(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('alerts') && null !== $data->getAlerts()) {
+        if ($data->isInitialized('alerts')) {
             $dataArray['alerts'] = $data->getAlerts();
         }
-        $dataArray['page'] = $data->getPage() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getPage(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
-        if ($data->isInitialized('requestId') && null !== $data->getRequestId()) {
+        $dataArray['page'] = $this->normalizer->normalize($data->getPage(), 'json', $context);
+        if ($data->isInitialized('requestId')) {
             $dataArray['request_id'] = $data->getRequestId();
         }
-        if ($data->isInitialized('warnings') && null !== $data->getWarnings()) {
+        if ($data->isInitialized('warnings')) {
             $dataArray['warnings'] = $data->getWarnings();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/DocumentListResponseNormalizer.php
+++ b/src/Normalizer/DocumentListResponseNormalizer.php
@@ -27,19 +27,18 @@ class DocumentListResponseNormalizer implements DenormalizerInterface, Normalize
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\DocumentListResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\DocumentListResponse();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('meta', $data)) {
             $object->setMeta($this->denormalizer->denormalize($data['meta'], \Silverstripe\Search\Client\Model\DocumentListResponseMeta::class, 'json', $context));
-            unset($data['meta']);
         }
         if (\array_key_exists('results', $data)) {
             $values = [];
@@ -51,33 +50,22 @@ class DocumentListResponseNormalizer implements DenormalizerInterface, Normalize
                 $values[] = $values_1;
             }
             $object->setResults($values);
-            unset($data['results']);
-        }
-        foreach ($data as $key_1 => $value_2) {
-            if (preg_match('/.*/', (string) $key_1)) {
-                $object[$key_1] = $value_2;
-            }
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        $dataArray['meta'] = $data->getMeta() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getMeta(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+        $dataArray['meta'] = $this->normalizer->normalize($data->getMeta(), 'json', $context);
         $values = [];
         foreach ($data->getResults() as $value) {
-            $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+            $values_1 = [];
             foreach ($value as $key => $value_1) {
                 $values_1[$key] = $value_1;
             }
             $values[] = $values_1;
         }
         $dataArray['results'] = $values;
-        foreach ($data as $key_1 => $value_2) {
-            if (preg_match('/.*/', (string) $key_1)) {
-                $dataArray[$key_1] = $value_2;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/DocumentPostPatchResponseNormalizer.php
+++ b/src/Normalizer/DocumentPostPatchResponseNormalizer.php
@@ -27,28 +27,24 @@ class DocumentPostPatchResponseNormalizer implements DenormalizerInterface, Norm
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\DocumentPostPatchResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\DocumentPostPatchResponse();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);
-            unset($data['id']);
         }
-        if (\array_key_exists('errors', $data)) {
+        if (\array_key_exists('errors', $data) && $data['errors'] !== null) {
             $object->setErrors($data['errors']);
-            unset($data['errors']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('errors', $data) && $data['errors'] === null) {
+            $object->setErrors(null);
         }
         return $object;
     }
@@ -56,13 +52,8 @@ class DocumentPostPatchResponseNormalizer implements DenormalizerInterface, Norm
     {
         $dataArray = [];
         $dataArray['id'] = $data->getId();
-        if ($data->isInitialized('errors') && null !== $data->getErrors()) {
+        if ($data->isInitialized('errors')) {
             $dataArray['errors'] = $data->getErrors();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/DocumentResponseMetaNormalizer.php
+++ b/src/Normalizer/DocumentResponseMetaNormalizer.php
@@ -27,51 +27,47 @@ class DocumentResponseMetaNormalizer implements DenormalizerInterface, Normalize
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\DocumentResponseMeta();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\DocumentResponseMeta();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('score', $data)) {
+        if (\array_key_exists('score', $data) && $data['score'] !== null) {
             $object->setScore($data['score']);
-            unset($data['score']);
         }
-        if (\array_key_exists('engine', $data)) {
+        elseif (\array_key_exists('score', $data) && $data['score'] === null) {
+            $object->setScore(null);
+        }
+        if (\array_key_exists('engine', $data) && $data['engine'] !== null) {
             $object->setEngine($data['engine']);
-            unset($data['engine']);
         }
-        if (\array_key_exists('id', $data)) {
+        elseif (\array_key_exists('engine', $data) && $data['engine'] === null) {
+            $object->setEngine(null);
+        }
+        if (\array_key_exists('id', $data) && $data['id'] !== null) {
             $object->setId($data['id']);
-            unset($data['id']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('id', $data) && $data['id'] === null) {
+            $object->setId(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('score') && null !== $data->getScore()) {
+        if ($data->isInitialized('score')) {
             $dataArray['score'] = $data->getScore();
         }
-        if ($data->isInitialized('engine') && null !== $data->getEngine()) {
+        if ($data->isInitialized('engine')) {
             $dataArray['engine'] = $data->getEngine();
         }
-        if ($data->isInitialized('id') && null !== $data->getId()) {
+        if ($data->isInitialized('id')) {
             $dataArray['id'] = $data->getId();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/DocumentsDeleteResponseNormalizer.php
+++ b/src/Normalizer/DocumentsDeleteResponseNormalizer.php
@@ -27,31 +27,24 @@ class DocumentsDeleteResponseNormalizer implements DenormalizerInterface, Normal
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\DocumentsDeleteResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\DocumentsDeleteResponse();
         if (\array_key_exists('deleted', $data) && \is_int($data['deleted'])) {
             $data['deleted'] = (bool) $data['deleted'];
         }
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);
-            unset($data['id']);
         }
         if (\array_key_exists('deleted', $data)) {
             $object->setDeleted($data['deleted']);
-            unset($data['deleted']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -60,11 +53,6 @@ class DocumentsDeleteResponseNormalizer implements DenormalizerInterface, Normal
         $dataArray = [];
         $dataArray['id'] = $data->getId();
         $dataArray['deleted'] = $data->getDeleted();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/EngineNameNormalizer.php
+++ b/src/Normalizer/EngineNameNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class EngineNameNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\EngineName::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\EngineName::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\EngineName();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['name'] = $data->getName();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\EngineName::class => false];
+    }
+}

--- a/src/Normalizer/EnginesResponseNormalizer.php
+++ b/src/Normalizer/EnginesResponseNormalizer.php
@@ -27,28 +27,22 @@ class EnginesResponseNormalizer implements DenormalizerInterface, NormalizerInte
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\EnginesResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\EnginesResponse();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('results', $data)) {
             $values = [];
             foreach ($data['results'] as $value) {
-                $values[] = $this->denormalizer->denormalize($value, \Silverstripe\Search\Client\Model\Engine::class, 'json', $context);
+                $values[] = $this->denormalizer->denormalize($value, \Silverstripe\Search\Client\Model\EngineName::class, 'json', $context);
             }
             $object->setResults($values);
-            unset($data['results']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
         }
         return $object;
     }
@@ -57,14 +51,9 @@ class EnginesResponseNormalizer implements DenormalizerInterface, NormalizerInte
         $dataArray = [];
         $values = [];
         foreach ($data->getResults() as $value) {
-            $values[] = $value == null ? null : new \ArrayObject($this->normalizer->normalize($value, 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+            $values[] = $this->normalizer->normalize($value, 'json', $context);
         }
         $dataArray['results'] = $values;
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/FacetResponseNormalizer.php
+++ b/src/Normalizer/FacetResponseNormalizer.php
@@ -27,36 +27,37 @@ class FacetResponseNormalizer implements DenormalizerInterface, NormalizerInterf
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\FacetResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\FacetResponse();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('type', $data)) {
             $object->setType($data['type']);
-            unset($data['type']);
         }
-        if (\array_key_exists('name', $data)) {
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
             $object->setName($data['name']);
-            unset($data['name']);
+        }
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
         }
         if (\array_key_exists('data', $data)) {
             $values = [];
             foreach ($data['data'] as $value) {
-                $values[] = $value;
+                $value_1 = $value;
+                if (is_array($value) and isset($value['value']) and isset($value['count'])) {
+                    $value_1 = $this->denormalizer->denormalize($value, \Silverstripe\Search\Client\Model\ResponseFacetValue::class, 'json', $context);
+                } elseif (is_array($value) and isset($value['count'])) {
+                    $value_1 = $this->denormalizer->denormalize($value, \Silverstripe\Search\Client\Model\ResponseFacetRange::class, 'json', $context);
+                }
+                $values[] = $value_1;
             }
             $object->setData($values);
-            unset($data['data']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
         }
         return $object;
     }
@@ -64,19 +65,20 @@ class FacetResponseNormalizer implements DenormalizerInterface, NormalizerInterf
     {
         $dataArray = [];
         $dataArray['type'] = $data->getType();
-        if ($data->isInitialized('name') && null !== $data->getName()) {
+        if ($data->isInitialized('name')) {
             $dataArray['name'] = $data->getName();
         }
         $values = [];
         foreach ($data->getData() as $value) {
-            $values[] = $value;
+            $value_1 = $value;
+            if (is_object($value)) {
+                $value_1 = $this->normalizer->normalize($value, 'json', $context);
+            } elseif (is_object($value)) {
+                $value_1 = $this->normalizer->normalize($value, 'json', $context);
+            }
+            $values[] = $value_1;
         }
         $dataArray['data'] = $values;
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/FilterObjectLevel1Normalizer.php
+++ b/src/Normalizer/FilterObjectLevel1Normalizer.php
@@ -27,51 +27,47 @@ class FilterObjectLevel1Normalizer implements DenormalizerInterface, NormalizerI
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\FilterObjectLevel1();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\FilterObjectLevel1();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('all', $data)) {
+        if (\array_key_exists('all', $data) && $data['all'] !== null) {
             $object->setAll($data['all']);
-            unset($data['all']);
         }
-        if (\array_key_exists('any', $data)) {
+        elseif (\array_key_exists('all', $data) && $data['all'] === null) {
+            $object->setAll(null);
+        }
+        if (\array_key_exists('any', $data) && $data['any'] !== null) {
             $object->setAny($data['any']);
-            unset($data['any']);
         }
-        if (\array_key_exists('none', $data)) {
+        elseif (\array_key_exists('any', $data) && $data['any'] === null) {
+            $object->setAny(null);
+        }
+        if (\array_key_exists('none', $data) && $data['none'] !== null) {
             $object->setNone($data['none']);
-            unset($data['none']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('none', $data) && $data['none'] === null) {
+            $object->setNone(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('all') && null !== $data->getAll()) {
+        if ($data->isInitialized('all')) {
             $dataArray['all'] = $data->getAll();
         }
-        if ($data->isInitialized('any') && null !== $data->getAny()) {
+        if ($data->isInitialized('any')) {
             $dataArray['any'] = $data->getAny();
         }
-        if ($data->isInitialized('none') && null !== $data->getNone()) {
+        if ($data->isInitialized('none')) {
             $dataArray['none'] = $data->getNone();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/FilterObjectLevel2Normalizer.php
+++ b/src/Normalizer/FilterObjectLevel2Normalizer.php
@@ -27,51 +27,47 @@ class FilterObjectLevel2Normalizer implements DenormalizerInterface, NormalizerI
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\FilterObjectLevel2();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\FilterObjectLevel2();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('all', $data)) {
+        if (\array_key_exists('all', $data) && $data['all'] !== null) {
             $object->setAll($data['all']);
-            unset($data['all']);
         }
-        if (\array_key_exists('any', $data)) {
+        elseif (\array_key_exists('all', $data) && $data['all'] === null) {
+            $object->setAll(null);
+        }
+        if (\array_key_exists('any', $data) && $data['any'] !== null) {
             $object->setAny($data['any']);
-            unset($data['any']);
         }
-        if (\array_key_exists('none', $data)) {
+        elseif (\array_key_exists('any', $data) && $data['any'] === null) {
+            $object->setAny(null);
+        }
+        if (\array_key_exists('none', $data) && $data['none'] !== null) {
             $object->setNone($data['none']);
-            unset($data['none']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('none', $data) && $data['none'] === null) {
+            $object->setNone(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('all') && null !== $data->getAll()) {
+        if ($data->isInitialized('all')) {
             $dataArray['all'] = $data->getAll();
         }
-        if ($data->isInitialized('any') && null !== $data->getAny()) {
+        if ($data->isInitialized('any')) {
             $dataArray['any'] = $data->getAny();
         }
-        if ($data->isInitialized('none') && null !== $data->getNone()) {
+        if ($data->isInitialized('none')) {
             $dataArray['none'] = $data->getNone();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/FilterObjectLevel3Normalizer.php
+++ b/src/Normalizer/FilterObjectLevel3Normalizer.php
@@ -27,51 +27,47 @@ class FilterObjectLevel3Normalizer implements DenormalizerInterface, NormalizerI
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\FilterObjectLevel3();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\FilterObjectLevel3();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('all', $data)) {
+        if (\array_key_exists('all', $data) && $data['all'] !== null) {
             $object->setAll($data['all']);
-            unset($data['all']);
         }
-        if (\array_key_exists('any', $data)) {
+        elseif (\array_key_exists('all', $data) && $data['all'] === null) {
+            $object->setAll(null);
+        }
+        if (\array_key_exists('any', $data) && $data['any'] !== null) {
             $object->setAny($data['any']);
-            unset($data['any']);
         }
-        if (\array_key_exists('none', $data)) {
+        elseif (\array_key_exists('any', $data) && $data['any'] === null) {
+            $object->setAny(null);
+        }
+        if (\array_key_exists('none', $data) && $data['none'] !== null) {
             $object->setNone($data['none']);
-            unset($data['none']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('none', $data) && $data['none'] === null) {
+            $object->setNone(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('all') && null !== $data->getAll()) {
+        if ($data->isInitialized('all')) {
             $dataArray['all'] = $data->getAll();
         }
-        if ($data->isInitialized('any') && null !== $data->getAny()) {
+        if ($data->isInitialized('any')) {
             $dataArray['any'] = $data->getAny();
         }
-        if ($data->isInitialized('none') && null !== $data->getNone()) {
+        if ($data->isInitialized('none')) {
             $dataArray['none'] = $data->getNone();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/FilterObjectLevel4Normalizer.php
+++ b/src/Normalizer/FilterObjectLevel4Normalizer.php
@@ -27,51 +27,47 @@ class FilterObjectLevel4Normalizer implements DenormalizerInterface, NormalizerI
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\FilterObjectLevel4();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\FilterObjectLevel4();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('all', $data)) {
+        if (\array_key_exists('all', $data) && $data['all'] !== null) {
             $object->setAll($data['all']);
-            unset($data['all']);
         }
-        if (\array_key_exists('any', $data)) {
+        elseif (\array_key_exists('all', $data) && $data['all'] === null) {
+            $object->setAll(null);
+        }
+        if (\array_key_exists('any', $data) && $data['any'] !== null) {
             $object->setAny($data['any']);
-            unset($data['any']);
         }
-        if (\array_key_exists('none', $data)) {
+        elseif (\array_key_exists('any', $data) && $data['any'] === null) {
+            $object->setAny(null);
+        }
+        if (\array_key_exists('none', $data) && $data['none'] !== null) {
             $object->setNone($data['none']);
-            unset($data['none']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('none', $data) && $data['none'] === null) {
+            $object->setNone(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('all') && null !== $data->getAll()) {
+        if ($data->isInitialized('all')) {
             $dataArray['all'] = $data->getAll();
         }
-        if ($data->isInitialized('any') && null !== $data->getAny()) {
+        if ($data->isInitialized('any')) {
             $dataArray['any'] = $data->getAny();
         }
-        if ($data->isInitialized('none') && null !== $data->getNone()) {
+        if ($data->isInitialized('none')) {
             $dataArray['none'] = $data->getNone();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/FiltersNormalizer.php
+++ b/src/Normalizer/FiltersNormalizer.php
@@ -27,51 +27,47 @@ class FiltersNormalizer implements DenormalizerInterface, NormalizerInterface, D
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\Filters();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\Filters();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('all', $data)) {
+        if (\array_key_exists('all', $data) && $data['all'] !== null) {
             $object->setAll($data['all']);
-            unset($data['all']);
         }
-        if (\array_key_exists('any', $data)) {
+        elseif (\array_key_exists('all', $data) && $data['all'] === null) {
+            $object->setAll(null);
+        }
+        if (\array_key_exists('any', $data) && $data['any'] !== null) {
             $object->setAny($data['any']);
-            unset($data['any']);
         }
-        if (\array_key_exists('none', $data)) {
+        elseif (\array_key_exists('any', $data) && $data['any'] === null) {
+            $object->setAny(null);
+        }
+        if (\array_key_exists('none', $data) && $data['none'] !== null) {
             $object->setNone($data['none']);
-            unset($data['none']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('none', $data) && $data['none'] === null) {
+            $object->setNone(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('all') && null !== $data->getAll()) {
+        if ($data->isInitialized('all')) {
             $dataArray['all'] = $data->getAll();
         }
-        if ($data->isInitialized('any') && null !== $data->getAny()) {
+        if ($data->isInitialized('any')) {
             $dataArray['any'] = $data->getAny();
         }
-        if ($data->isInitialized('none') && null !== $data->getNone()) {
+        if ($data->isInitialized('none')) {
             $dataArray['none'] = $data->getNone();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/GeoNormalizer.php
+++ b/src/Normalizer/GeoNormalizer.php
@@ -27,23 +27,27 @@ class GeoNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\Geo();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\Geo();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('from', $data)) {
+        if (\array_key_exists('from', $data) && $data['from'] !== null) {
             $object->setFrom($data['from']);
-            unset($data['from']);
         }
-        if (\array_key_exists('to', $data)) {
+        elseif (\array_key_exists('from', $data) && $data['from'] === null) {
+            $object->setFrom(null);
+        }
+        if (\array_key_exists('to', $data) && $data['to'] !== null) {
             $object->setTo($data['to']);
-            unset($data['to']);
+        }
+        elseif (\array_key_exists('to', $data) && $data['to'] === null) {
+            $object->setTo(null);
         }
         if (\array_key_exists('center', $data)) {
             $value = $data['center'];
@@ -59,35 +63,30 @@ class GeoNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
                 $value = $data['center'];
             }
             $object->setCenter($value);
-            unset($data['center']);
         }
         if (\array_key_exists('unit', $data)) {
             $object->setUnit($data['unit']);
-            unset($data['unit']);
         }
-        if (\array_key_exists('distance', $data)) {
+        if (\array_key_exists('distance', $data) && $data['distance'] !== null) {
             $object->setDistance($data['distance']);
-            unset($data['distance']);
         }
-        foreach ($data as $key => $value_2) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_2;
-            }
+        elseif (\array_key_exists('distance', $data) && $data['distance'] === null) {
+            $object->setDistance(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('from') && null !== $data->getFrom()) {
+        if ($data->isInitialized('from')) {
             $dataArray['from'] = $data->getFrom();
         }
-        if ($data->isInitialized('to') && null !== $data->getTo()) {
+        if ($data->isInitialized('to')) {
             $dataArray['to'] = $data->getTo();
         }
         $value = $data->getCenter();
         if (is_object($data->getCenter())) {
-            $value = $data->getCenter() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getCenter(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+            $value = $this->normalizer->normalize($data->getCenter(), 'json', $context);
         } elseif (is_array($data->getCenter())) {
             $values = [];
             foreach ($data->getCenter() as $value_1) {
@@ -99,13 +98,8 @@ class GeoNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
         }
         $dataArray['center'] = $value;
         $dataArray['unit'] = $data->getUnit();
-        if ($data->isInitialized('distance') && null !== $data->getDistance()) {
+        if ($data->isInitialized('distance')) {
             $dataArray['distance'] = $data->getDistance();
-        }
-        foreach ($data as $key => $value_2) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_2;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/GeolocationNormalizer.php
+++ b/src/Normalizer/GeolocationNormalizer.php
@@ -27,15 +27,15 @@ class GeolocationNormalizer implements DenormalizerInterface, NormalizerInterfac
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\Geolocation();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \Silverstripe\Search\Client\Model\Geolocation();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('center', $data)) {
             $value = $data['center'];
@@ -51,16 +51,9 @@ class GeolocationNormalizer implements DenormalizerInterface, NormalizerInterfac
                 $value = $data['center'];
             }
             $object->setCenter($value);
-            unset($data['center']);
         }
         if (\array_key_exists('order', $data)) {
             $object->setOrder($data['order']);
-            unset($data['order']);
-        }
-        foreach ($data as $key => $value_2) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_2;
-            }
         }
         return $object;
     }
@@ -69,7 +62,7 @@ class GeolocationNormalizer implements DenormalizerInterface, NormalizerInterfac
         $dataArray = [];
         $value = $data->getCenter();
         if (is_object($data->getCenter())) {
-            $value = $data->getCenter() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getCenter(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+            $value = $this->normalizer->normalize($data->getCenter(), 'json', $context);
         } elseif (is_array($data->getCenter())) {
             $values = [];
             foreach ($data->getCenter() as $value_1) {
@@ -81,11 +74,6 @@ class GeolocationNormalizer implements DenormalizerInterface, NormalizerInterfac
         }
         $dataArray['center'] = $value;
         $dataArray['order'] = $data->getOrder();
-        foreach ($data as $key => $value_2) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_2;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/HTTPValidationErrorNormalizer.php
+++ b/src/Normalizer/HTTPValidationErrorNormalizer.php
@@ -27,15 +27,15 @@ class HTTPValidationErrorNormalizer implements DenormalizerInterface, Normalizer
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\HTTPValidationError();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \Silverstripe\Search\Client\Model\HTTPValidationError();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('detail', $data)) {
             $values = [];
@@ -43,12 +43,6 @@ class HTTPValidationErrorNormalizer implements DenormalizerInterface, Normalizer
                 $values[] = $this->denormalizer->denormalize($value, \Silverstripe\Search\Client\Model\ValidationError::class, 'json', $context);
             }
             $object->setDetail($values);
-            unset($data['detail']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
         }
         return $object;
     }
@@ -58,14 +52,9 @@ class HTTPValidationErrorNormalizer implements DenormalizerInterface, Normalizer
         if ($data->isInitialized('detail') && null !== $data->getDetail()) {
             $values = [];
             foreach ($data->getDetail() as $value) {
-                $values[] = $value == null ? null : new \ArrayObject($this->normalizer->normalize($value, 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                $values[] = $this->normalizer->normalize($value, 'json', $context);
             }
             $dataArray['detail'] = $values;
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/JaneObjectNormalizer.php
+++ b/src/Normalizer/JaneObjectNormalizer.php
@@ -18,9 +18,21 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     use ValidatorTrait;
     protected $normalizers = [
         
+        \Silverstripe\Search\Client\Model\BoostGetResponse::class => \Silverstripe\Search\Client\Normalizer\BoostGetResponseNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\BoostPatchRequest::class => \Silverstripe\Search\Client\Normalizer\BoostPatchRequestNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\BoostPostRequest::class => \Silverstripe\Search\Client\Normalizer\BoostPostRequestNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\BoostPostResponse::class => \Silverstripe\Search\Client\Normalizer\BoostPostResponseNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\ClickRequest::class => \Silverstripe\Search\Client\Normalizer\ClickRequestNormalizer::class,
+        
         \Silverstripe\Search\Client\Model\Coordinate::class => \Silverstripe\Search\Client\Normalizer\CoordinateNormalizer::class,
         
         \Silverstripe\Search\Client\Model\DocumentField::class => \Silverstripe\Search\Client\Normalizer\DocumentFieldNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\DocumentListPagination::class => \Silverstripe\Search\Client\Normalizer\DocumentListPaginationNormalizer::class,
         
         \Silverstripe\Search\Client\Model\DocumentListRequest::class => \Silverstripe\Search\Client\Normalizer\DocumentListRequestNormalizer::class,
         
@@ -34,7 +46,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Silverstripe\Search\Client\Model\DocumentsDeleteResponse::class => \Silverstripe\Search\Client\Normalizer\DocumentsDeleteResponseNormalizer::class,
         
-        \Silverstripe\Search\Client\Model\Engine::class => \Silverstripe\Search\Client\Normalizer\EngineNormalizer::class,
+        \Silverstripe\Search\Client\Model\EngineName::class => \Silverstripe\Search\Client\Normalizer\EngineNameNormalizer::class,
         
         \Silverstripe\Search\Client\Model\EnginesResponse::class => \Silverstripe\Search\Client\Normalizer\EnginesResponseNormalizer::class,
         
@@ -56,9 +68,9 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Silverstripe\Search\Client\Model\HTTPValidationError::class => \Silverstripe\Search\Client\Normalizer\HTTPValidationErrorNormalizer::class,
         
-        \Silverstripe\Search\Client\Model\PaginationNoTotals::class => \Silverstripe\Search\Client\Normalizer\PaginationNoTotalsNormalizer::class,
+        \Silverstripe\Search\Client\Model\PaginationResponse::class => \Silverstripe\Search\Client\Normalizer\PaginationResponseNormalizer::class,
         
-        \Silverstripe\Search\Client\Model\PaginationWithTotals::class => \Silverstripe\Search\Client\Normalizer\PaginationWithTotalsNormalizer::class,
+        \Silverstripe\Search\Client\Model\PostResponse::class => \Silverstripe\Search\Client\Normalizer\PostResponseNormalizer::class,
         
         \Silverstripe\Search\Client\Model\QuerySuggestionRequest::class => \Silverstripe\Search\Client\Normalizer\QuerySuggestionRequestNormalizer::class,
         
@@ -74,6 +86,10 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Silverstripe\Search\Client\Model\RequestFacetValue::class => \Silverstripe\Search\Client\Normalizer\RequestFacetValueNormalizer::class,
         
+        \Silverstripe\Search\Client\Model\ResponseAcknowledged::class => \Silverstripe\Search\Client\Normalizer\ResponseAcknowledgedNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\ResponseConfirm::class => \Silverstripe\Search\Client\Normalizer\ResponseConfirmNormalizer::class,
+        
         \Silverstripe\Search\Client\Model\ResponseFacetRange::class => \Silverstripe\Search\Client\Normalizer\ResponseFacetRangeNormalizer::class,
         
         \Silverstripe\Search\Client\Model\ResponseFacetValue::class => \Silverstripe\Search\Client\Normalizer\ResponseFacetValueNormalizer::class,
@@ -82,9 +98,13 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Silverstripe\Search\Client\Model\Schema::class => \Silverstripe\Search\Client\Normalizer\SchemaNormalizer::class,
         
-        \Silverstripe\Search\Client\Model\SchemaPostResponse::class => \Silverstripe\Search\Client\Normalizer\SchemaPostResponseNormalizer::class,
+        \Silverstripe\Search\Client\Model\SchemaGetResponse::class => \Silverstripe\Search\Client\Normalizer\SchemaGetResponseNormalizer::class,
         
         \Silverstripe\Search\Client\Model\SearchRequest::class => \Silverstripe\Search\Client\Normalizer\SearchRequestNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\SearchRequestBoost::class => \Silverstripe\Search\Client\Normalizer\SearchRequestBoostNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\SearchRequestPagination::class => \Silverstripe\Search\Client\Normalizer\SearchRequestPaginationNormalizer::class,
         
         \Silverstripe\Search\Client\Model\SearchRequestResultField::class => \Silverstripe\Search\Client\Normalizer\SearchRequestResultFieldNormalizer::class,
         
@@ -115,6 +135,22 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         \Silverstripe\Search\Client\Model\Tags::class => \Silverstripe\Search\Client\Normalizer\TagsNormalizer::class,
         
         \Silverstripe\Search\Client\Model\ValidationError::class => \Silverstripe\Search\Client\Normalizer\ValidationErrorNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse::class => \Silverstripe\Search\Client\Normalizer\CommonModelsCurationGetResponseGetResponseNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest::class => \Silverstripe\Search\Client\Normalizer\CommonModelsCurationPatchRequestPatchRequestNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest::class => \Silverstripe\Search\Client\Normalizer\CommonModelsCurationPostRequestPostRequestNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse::class => \Silverstripe\Search\Client\Normalizer\CommonModelsCurationDocumentGetResponseGetResponseNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest::class => \Silverstripe\Search\Client\Normalizer\CommonModelsCurationDocumentPatchRequestPatchRequestNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest::class => \Silverstripe\Search\Client\Normalizer\CommonModelsCurationDocumentPostRequestPostRequestNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse::class => \Silverstripe\Search\Client\Normalizer\CommonModelsCurationQueryGetResponseGetResponseNormalizer::class,
+        
+        \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest::class => \Silverstripe\Search\Client\Normalizer\CommonModelsCurationQueryPostRequestPostRequestNormalizer::class,
         
         \Jane\Component\JsonSchemaRuntime\Reference::class => \Silverstripe\Search\Client\Runtime\Normalizer\ReferenceNormalizer::class,
     ], $normalizersCache = [];
@@ -154,15 +190,21 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     {
         return [
             
+            \Silverstripe\Search\Client\Model\BoostGetResponse::class => false,
+            \Silverstripe\Search\Client\Model\BoostPatchRequest::class => false,
+            \Silverstripe\Search\Client\Model\BoostPostRequest::class => false,
+            \Silverstripe\Search\Client\Model\BoostPostResponse::class => false,
+            \Silverstripe\Search\Client\Model\ClickRequest::class => false,
             \Silverstripe\Search\Client\Model\Coordinate::class => false,
             \Silverstripe\Search\Client\Model\DocumentField::class => false,
+            \Silverstripe\Search\Client\Model\DocumentListPagination::class => false,
             \Silverstripe\Search\Client\Model\DocumentListRequest::class => false,
             \Silverstripe\Search\Client\Model\DocumentListResponse::class => false,
             \Silverstripe\Search\Client\Model\DocumentListResponseMeta::class => false,
             \Silverstripe\Search\Client\Model\DocumentPostPatchResponse::class => false,
             \Silverstripe\Search\Client\Model\DocumentResponseMeta::class => false,
             \Silverstripe\Search\Client\Model\DocumentsDeleteResponse::class => false,
-            \Silverstripe\Search\Client\Model\Engine::class => false,
+            \Silverstripe\Search\Client\Model\EngineName::class => false,
             \Silverstripe\Search\Client\Model\EnginesResponse::class => false,
             \Silverstripe\Search\Client\Model\FacetResponse::class => false,
             \Silverstripe\Search\Client\Model\FilterObjectLevel1::class => false,
@@ -173,8 +215,8 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Silverstripe\Search\Client\Model\Geo::class => false,
             \Silverstripe\Search\Client\Model\Geolocation::class => false,
             \Silverstripe\Search\Client\Model\HTTPValidationError::class => false,
-            \Silverstripe\Search\Client\Model\PaginationNoTotals::class => false,
-            \Silverstripe\Search\Client\Model\PaginationWithTotals::class => false,
+            \Silverstripe\Search\Client\Model\PaginationResponse::class => false,
+            \Silverstripe\Search\Client\Model\PostResponse::class => false,
             \Silverstripe\Search\Client\Model\QuerySuggestionRequest::class => false,
             \Silverstripe\Search\Client\Model\QuerySuggestionResponse::class => false,
             \Silverstripe\Search\Client\Model\QuerySuggestionResponseValue::class => false,
@@ -182,12 +224,16 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Silverstripe\Search\Client\Model\RequestFacetRange::class => false,
             \Silverstripe\Search\Client\Model\RequestFacetRangeObject::class => false,
             \Silverstripe\Search\Client\Model\RequestFacetValue::class => false,
+            \Silverstripe\Search\Client\Model\ResponseAcknowledged::class => false,
+            \Silverstripe\Search\Client\Model\ResponseConfirm::class => false,
             \Silverstripe\Search\Client\Model\ResponseFacetRange::class => false,
             \Silverstripe\Search\Client\Model\ResponseFacetValue::class => false,
             \Silverstripe\Search\Client\Model\ResponseSuccess::class => false,
             \Silverstripe\Search\Client\Model\Schema::class => false,
-            \Silverstripe\Search\Client\Model\SchemaPostResponse::class => false,
+            \Silverstripe\Search\Client\Model\SchemaGetResponse::class => false,
             \Silverstripe\Search\Client\Model\SearchRequest::class => false,
+            \Silverstripe\Search\Client\Model\SearchRequestBoost::class => false,
+            \Silverstripe\Search\Client\Model\SearchRequestPagination::class => false,
             \Silverstripe\Search\Client\Model\SearchRequestResultField::class => false,
             \Silverstripe\Search\Client\Model\SearchRequestResultFieldRaw::class => false,
             \Silverstripe\Search\Client\Model\SearchRequestResultFieldSnippet::class => false,
@@ -203,6 +249,14 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Silverstripe\Search\Client\Model\SynonymRuleRequest::class => false,
             \Silverstripe\Search\Client\Model\Tags::class => false,
             \Silverstripe\Search\Client\Model\ValidationError::class => false,
+            \Silverstripe\Search\Client\Model\CommonModelsCurationGetResponseGetResponse::class => false,
+            \Silverstripe\Search\Client\Model\CommonModelsCurationPatchRequestPatchRequest::class => false,
+            \Silverstripe\Search\Client\Model\CommonModelsCurationPostRequestPostRequest::class => false,
+            \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentGetResponseGetResponse::class => false,
+            \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPatchRequestPatchRequest::class => false,
+            \Silverstripe\Search\Client\Model\CommonModelsCurationDocumentPostRequestPostRequest::class => false,
+            \Silverstripe\Search\Client\Model\CommonModelsCurationQueryGetResponseGetResponse::class => false,
+            \Silverstripe\Search\Client\Model\CommonModelsCurationQueryPostRequestPostRequest::class => false,
             \Jane\Component\JsonSchemaRuntime\Reference::class => false,
         ];
     }

--- a/src/Normalizer/PaginationResponseNormalizer.php
+++ b/src/Normalizer/PaginationResponseNormalizer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class PaginationResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\PaginationResponse::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\PaginationResponse::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\PaginationResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('current', $data)) {
+            $object->setCurrent($data['current']);
+        }
+        if (\array_key_exists('size', $data)) {
+            $object->setSize($data['size']);
+        }
+        if (\array_key_exists('total_pages', $data)) {
+            $object->setTotalPages($data['total_pages']);
+        }
+        if (\array_key_exists('total_results', $data)) {
+            $object->setTotalResults($data['total_results']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['current'] = $data->getCurrent();
+        $dataArray['size'] = $data->getSize();
+        $dataArray['total_pages'] = $data->getTotalPages();
+        $dataArray['total_results'] = $data->getTotalResults();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\PaginationResponse::class => false];
+    }
+}

--- a/src/Normalizer/PostResponseNormalizer.php
+++ b/src/Normalizer/PostResponseNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class PostResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\PostResponse::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\PostResponse::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\PostResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('uuid', $data)) {
+            $object->setUuid($data['uuid']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['uuid'] = $data->getUuid();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\PostResponse::class => false];
+    }
+}

--- a/src/Normalizer/QuerySuggestionRequestNormalizer.php
+++ b/src/Normalizer/QuerySuggestionRequestNormalizer.php
@@ -27,32 +27,27 @@ class QuerySuggestionRequestNormalizer implements DenormalizerInterface, Normali
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\QuerySuggestionRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\QuerySuggestionRequest();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('query', $data)) {
             $object->setQuery($data['query']);
-            unset($data['query']);
         }
         if (\array_key_exists('size', $data)) {
             $object->setSize($data['size']);
-            unset($data['size']);
         }
-        if (\array_key_exists('fields', $data)) {
+        if (\array_key_exists('fields', $data) && $data['fields'] !== null) {
             $object->setFields($data['fields']);
-            unset($data['fields']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('fields', $data) && $data['fields'] === null) {
+            $object->setFields(null);
         }
         return $object;
     }
@@ -63,13 +58,8 @@ class QuerySuggestionRequestNormalizer implements DenormalizerInterface, Normali
         if ($data->isInitialized('size') && null !== $data->getSize()) {
             $dataArray['size'] = $data->getSize();
         }
-        if ($data->isInitialized('fields') && null !== $data->getFields()) {
+        if ($data->isInitialized('fields')) {
             $dataArray['fields'] = $data->getFields();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/QuerySuggestionResponseNormalizer.php
+++ b/src/Normalizer/QuerySuggestionResponseNormalizer.php
@@ -27,15 +27,15 @@ class QuerySuggestionResponseNormalizer implements DenormalizerInterface, Normal
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\QuerySuggestionResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \Silverstripe\Search\Client\Model\QuerySuggestionResponse();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('results', $data)) {
             $values = [];
@@ -43,12 +43,6 @@ class QuerySuggestionResponseNormalizer implements DenormalizerInterface, Normal
                 $values[] = $this->denormalizer->denormalize($value, \Silverstripe\Search\Client\Model\QuerySuggestionResponseValue::class, 'json', $context);
             }
             $object->setResults($values);
-            unset($data['results']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
         }
         return $object;
     }
@@ -57,14 +51,9 @@ class QuerySuggestionResponseNormalizer implements DenormalizerInterface, Normal
         $dataArray = [];
         $values = [];
         foreach ($data->getResults() as $value) {
-            $values[] = $value == null ? null : new \ArrayObject($this->normalizer->normalize($value, 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+            $values[] = $this->normalizer->normalize($value, 'json', $context);
         }
         $dataArray['results'] = $values;
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/QuerySuggestionResponseValueNormalizer.php
+++ b/src/Normalizer/QuerySuggestionResponseValueNormalizer.php
@@ -27,24 +27,18 @@ class QuerySuggestionResponseValueNormalizer implements DenormalizerInterface, N
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\QuerySuggestionResponseValue();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\QuerySuggestionResponseValue();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('raw', $data)) {
             $object->setRaw($data['raw']);
-            unset($data['raw']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -52,11 +46,6 @@ class QuerySuggestionResponseValueNormalizer implements DenormalizerInterface, N
     {
         $dataArray = [];
         $dataArray['raw'] = $data->getRaw();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/RangeNormalizer.php
+++ b/src/Normalizer/RangeNormalizer.php
@@ -27,44 +27,38 @@ class RangeNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\Range();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\Range();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('from', $data)) {
+        if (\array_key_exists('from', $data) && $data['from'] !== null) {
             $object->setFrom($data['from']);
-            unset($data['from']);
         }
-        if (\array_key_exists('to', $data)) {
+        elseif (\array_key_exists('from', $data) && $data['from'] === null) {
+            $object->setFrom(null);
+        }
+        if (\array_key_exists('to', $data) && $data['to'] !== null) {
             $object->setTo($data['to']);
-            unset($data['to']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('to', $data) && $data['to'] === null) {
+            $object->setTo(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('from') && null !== $data->getFrom()) {
+        if ($data->isInitialized('from')) {
             $dataArray['from'] = $data->getFrom();
         }
-        if ($data->isInitialized('to') && null !== $data->getTo()) {
+        if ($data->isInitialized('to')) {
             $dataArray['to'] = $data->getTo();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/RequestFacetRangeNormalizer.php
+++ b/src/Normalizer/RequestFacetRangeNormalizer.php
@@ -27,23 +27,24 @@ class RequestFacetRangeNormalizer implements DenormalizerInterface, NormalizerIn
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\RequestFacetRange();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\RequestFacetRange();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('type', $data)) {
             $object->setType($data['type']);
-            unset($data['type']);
         }
-        if (\array_key_exists('name', $data)) {
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
             $object->setName($data['name']);
-            unset($data['name']);
+        }
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
         }
         if (\array_key_exists('ranges', $data)) {
             $values = [];
@@ -51,12 +52,6 @@ class RequestFacetRangeNormalizer implements DenormalizerInterface, NormalizerIn
                 $values[] = $this->denormalizer->denormalize($value, \Silverstripe\Search\Client\Model\RequestFacetRangeObject::class, 'json', $context);
             }
             $object->setRanges($values);
-            unset($data['ranges']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
         }
         return $object;
     }
@@ -64,19 +59,14 @@ class RequestFacetRangeNormalizer implements DenormalizerInterface, NormalizerIn
     {
         $dataArray = [];
         $dataArray['type'] = $data->getType();
-        if ($data->isInitialized('name') && null !== $data->getName()) {
+        if ($data->isInitialized('name')) {
             $dataArray['name'] = $data->getName();
         }
         $values = [];
         foreach ($data->getRanges() as $value) {
-            $values[] = $value == null ? null : new \ArrayObject($this->normalizer->normalize($value, 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+            $values[] = $this->normalizer->normalize($value, 'json', $context);
         }
         $dataArray['ranges'] = $values;
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/RequestFacetRangeObjectNormalizer.php
+++ b/src/Normalizer/RequestFacetRangeObjectNormalizer.php
@@ -27,51 +27,47 @@ class RequestFacetRangeObjectNormalizer implements DenormalizerInterface, Normal
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\RequestFacetRangeObject();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\RequestFacetRangeObject();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('from', $data)) {
+        if (\array_key_exists('from', $data) && $data['from'] !== null) {
             $object->setFrom($data['from']);
-            unset($data['from']);
         }
-        if (\array_key_exists('to', $data)) {
+        elseif (\array_key_exists('from', $data) && $data['from'] === null) {
+            $object->setFrom(null);
+        }
+        if (\array_key_exists('to', $data) && $data['to'] !== null) {
             $object->setTo($data['to']);
-            unset($data['to']);
         }
-        if (\array_key_exists('name', $data)) {
+        elseif (\array_key_exists('to', $data) && $data['to'] === null) {
+            $object->setTo(null);
+        }
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
             $object->setName($data['name']);
-            unset($data['name']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('from') && null !== $data->getFrom()) {
+        if ($data->isInitialized('from')) {
             $dataArray['from'] = $data->getFrom();
         }
-        if ($data->isInitialized('to') && null !== $data->getTo()) {
+        if ($data->isInitialized('to')) {
             $dataArray['to'] = $data->getTo();
         }
-        if ($data->isInitialized('name') && null !== $data->getName()) {
+        if ($data->isInitialized('name')) {
             $dataArray['name'] = $data->getName();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/RequestFacetValueNormalizer.php
+++ b/src/Normalizer/RequestFacetValueNormalizer.php
@@ -27,29 +27,29 @@ class RequestFacetValueNormalizer implements DenormalizerInterface, NormalizerIn
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\RequestFacetValue();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\RequestFacetValue();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('type', $data)) {
             $object->setType($data['type']);
-            unset($data['type']);
         }
-        if (\array_key_exists('name', $data)) {
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
             $object->setName($data['name']);
-            unset($data['name']);
+        }
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
         }
         if (\array_key_exists('size', $data)) {
             $object->setSize($data['size']);
-            unset($data['size']);
         }
-        if (\array_key_exists('sort', $data)) {
+        if (\array_key_exists('sort', $data) && $data['sort'] !== null) {
             $value = $data['sort'];
             if (is_array($data['sort']) && $this->isOnlyNumericKeys($data['sort'])) {
                 $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
@@ -61,12 +61,9 @@ class RequestFacetValueNormalizer implements DenormalizerInterface, NormalizerIn
                 $value = $data['sort'];
             }
             $object->setSort($value);
-            unset($data['sort']);
         }
-        foreach ($data as $key_1 => $value_2) {
-            if (preg_match('/.*/', (string) $key_1)) {
-                $object[$key_1] = $value_2;
-            }
+        elseif (\array_key_exists('sort', $data) && $data['sort'] === null) {
+            $object->setSort(null);
         }
         return $object;
     }
@@ -74,16 +71,16 @@ class RequestFacetValueNormalizer implements DenormalizerInterface, NormalizerIn
     {
         $dataArray = [];
         $dataArray['type'] = $data->getType();
-        if ($data->isInitialized('name') && null !== $data->getName()) {
+        if ($data->isInitialized('name')) {
             $dataArray['name'] = $data->getName();
         }
         if ($data->isInitialized('size') && null !== $data->getSize()) {
             $dataArray['size'] = $data->getSize();
         }
-        if ($data->isInitialized('sort') && null !== $data->getSort()) {
+        if ($data->isInitialized('sort')) {
             $value = $data->getSort();
             if (is_object($data->getSort())) {
-                $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+                $values = [];
                 foreach ($data->getSort() as $key => $value_1) {
                     $values[$key] = $value_1;
                 }
@@ -92,11 +89,6 @@ class RequestFacetValueNormalizer implements DenormalizerInterface, NormalizerIn
                 $value = $data->getSort();
             }
             $dataArray['sort'] = $value;
-        }
-        foreach ($data as $key_1 => $value_2) {
-            if (preg_match('/.*/', (string) $key_1)) {
-                $dataArray[$key_1] = $value_2;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/ResponseAcknowledgedNormalizer.php
+++ b/src/Normalizer/ResponseAcknowledgedNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ResponseAcknowledgedNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\ResponseAcknowledged::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\ResponseAcknowledged::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\ResponseAcknowledged();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('acknowledged', $data) && \is_int($data['acknowledged'])) {
+            $data['acknowledged'] = (bool) $data['acknowledged'];
+        }
+        if (\array_key_exists('acknowledged', $data)) {
+            $object->setAcknowledged($data['acknowledged']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['acknowledged'] = $data->getAcknowledged();
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\ResponseAcknowledged::class => false];
+    }
+}

--- a/src/Normalizer/ResponseConfirmNormalizer.php
+++ b/src/Normalizer/ResponseConfirmNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class SchemaPostResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ResponseConfirmNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,51 +19,41 @@ class SchemaPostResponseNormalizer implements DenormalizerInterface, NormalizerI
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Silverstripe\Search\Client\Model\SchemaPostResponse::class;
+        return $type === \Silverstripe\Search\Client\Model\ResponseConfirm::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\SchemaPostResponse::class;
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\ResponseConfirm::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\ResponseConfirm();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SchemaPostResponse();
-        if (\array_key_exists('acknowledged', $data) && \is_int($data['acknowledged'])) {
-            $data['acknowledged'] = (bool) $data['acknowledged'];
+        if (\array_key_exists('message', $data)) {
+            $object->setMessage($data['message']);
         }
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('acknowledged', $data)) {
-            $object->setAcknowledged($data['acknowledged']);
-            unset($data['acknowledged']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        if (\array_key_exists('token', $data)) {
+            $object->setToken($data['token']);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        $dataArray['acknowledged'] = $data->getAcknowledged();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
+        $dataArray['message'] = $data->getMessage();
+        $dataArray['token'] = $data->getToken();
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Silverstripe\Search\Client\Model\SchemaPostResponse::class => false];
+        return [\Silverstripe\Search\Client\Model\ResponseConfirm::class => false];
     }
 }

--- a/src/Normalizer/ResponseFacetRangeNormalizer.php
+++ b/src/Normalizer/ResponseFacetRangeNormalizer.php
@@ -27,57 +27,52 @@ class ResponseFacetRangeNormalizer implements DenormalizerInterface, NormalizerI
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\ResponseFacetRange();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\ResponseFacetRange();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('from', $data)) {
+        if (\array_key_exists('from', $data) && $data['from'] !== null) {
             $object->setFrom($data['from']);
-            unset($data['from']);
         }
-        if (\array_key_exists('to', $data)) {
+        elseif (\array_key_exists('from', $data) && $data['from'] === null) {
+            $object->setFrom(null);
+        }
+        if (\array_key_exists('to', $data) && $data['to'] !== null) {
             $object->setTo($data['to']);
-            unset($data['to']);
         }
-        if (\array_key_exists('name', $data)) {
+        elseif (\array_key_exists('to', $data) && $data['to'] === null) {
+            $object->setTo(null);
+        }
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
             $object->setName($data['name']);
-            unset($data['name']);
+        }
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
         }
         if (\array_key_exists('count', $data)) {
             $object->setCount($data['count']);
-            unset($data['count']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('from') && null !== $data->getFrom()) {
+        if ($data->isInitialized('from')) {
             $dataArray['from'] = $data->getFrom();
         }
-        if ($data->isInitialized('to') && null !== $data->getTo()) {
+        if ($data->isInitialized('to')) {
             $dataArray['to'] = $data->getTo();
         }
-        if ($data->isInitialized('name') && null !== $data->getName()) {
+        if ($data->isInitialized('name')) {
             $dataArray['name'] = $data->getName();
         }
         $dataArray['count'] = $data->getCount();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/ResponseFacetValueNormalizer.php
+++ b/src/Normalizer/ResponseFacetValueNormalizer.php
@@ -27,28 +27,21 @@ class ResponseFacetValueNormalizer implements DenormalizerInterface, NormalizerI
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\ResponseFacetValue();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\ResponseFacetValue();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('value', $data)) {
             $object->setValue($data['value']);
-            unset($data['value']);
         }
         if (\array_key_exists('count', $data)) {
             $object->setCount($data['count']);
-            unset($data['count']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -57,11 +50,6 @@ class ResponseFacetValueNormalizer implements DenormalizerInterface, NormalizerI
         $dataArray = [];
         $dataArray['value'] = $data->getValue();
         $dataArray['count'] = $data->getCount();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/ResponseSuccessNormalizer.php
+++ b/src/Normalizer/ResponseSuccessNormalizer.php
@@ -27,27 +27,21 @@ class ResponseSuccessNormalizer implements DenormalizerInterface, NormalizerInte
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\ResponseSuccess();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\ResponseSuccess();
         if (\array_key_exists('success', $data) && \is_int($data['success'])) {
             $data['success'] = (bool) $data['success'];
         }
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('success', $data)) {
             $object->setSuccess($data['success']);
-            unset($data['success']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -55,11 +49,6 @@ class ResponseSuccessNormalizer implements DenormalizerInterface, NormalizerInte
     {
         $dataArray = [];
         $dataArray['success'] = $data->getSuccess();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/SchemaGetResponseNormalizer.php
+++ b/src/Normalizer/SchemaGetResponseNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class SchemaGetResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\SchemaGetResponse::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\SchemaGetResponse::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\SchemaGetResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\SchemaGetResponse::class => false];
+    }
+}

--- a/src/Normalizer/SchemaNormalizer.php
+++ b/src/Normalizer/SchemaNormalizer.php
@@ -27,23 +27,29 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\Schema();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\Schema();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('_attachment', $data)) {
+        if (\array_key_exists('_attachment', $data) && $data['_attachment'] !== null) {
             $object->setAttachment($data['_attachment']);
             unset($data['_attachment']);
         }
-        if (\array_key_exists('body', $data)) {
+        elseif (\array_key_exists('_attachment', $data) && $data['_attachment'] === null) {
+            $object->setAttachment(null);
+        }
+        if (\array_key_exists('body', $data) && $data['body'] !== null) {
             $object->setBody($data['body']);
             unset($data['body']);
+        }
+        elseif (\array_key_exists('body', $data) && $data['body'] === null) {
+            $object->setBody(null);
         }
         foreach ($data as $key => $value) {
             if (preg_match('/.*/', (string) $key)) {
@@ -55,10 +61,10 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('attachment') && null !== $data->getAttachment()) {
+        if ($data->isInitialized('attachment')) {
             $dataArray['_attachment'] = $data->getAttachment();
         }
-        if ($data->isInitialized('body') && null !== $data->getBody()) {
+        if ($data->isInitialized('body')) {
             $dataArray['body'] = $data->getBody();
         }
         foreach ($data as $key => $value) {

--- a/src/Normalizer/SearchRequestBoostNormalizer.php
+++ b/src/Normalizer/SearchRequestBoostNormalizer.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Silverstripe\Search\Client\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Silverstripe\Search\Client\Runtime\Normalizer\CheckArray;
+use Silverstripe\Search\Client\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class SearchRequestBoostNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Silverstripe\Search\Client\Model\SearchRequestBoost::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\SearchRequestBoost::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Silverstripe\Search\Client\Model\SearchRequestBoost();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('factor', $data) && \is_int($data['factor'])) {
+            $data['factor'] = (double) $data['factor'];
+        }
+        if (\array_key_exists('type', $data)) {
+            $object->setType($data['type']);
+        }
+        if (\array_key_exists('value', $data) && $data['value'] !== null) {
+            $object->setValue($data['value']);
+        }
+        elseif (\array_key_exists('value', $data) && $data['value'] === null) {
+            $object->setValue(null);
+        }
+        if (\array_key_exists('factor', $data)) {
+            $object->setFactor($data['factor']);
+        }
+        if (\array_key_exists('center', $data) && $data['center'] !== null) {
+            $object->setCenter($data['center']);
+        }
+        elseif (\array_key_exists('center', $data) && $data['center'] === null) {
+            $object->setCenter(null);
+        }
+        if (\array_key_exists('function', $data) && $data['function'] !== null) {
+            $object->setFunction($data['function']);
+        }
+        elseif (\array_key_exists('function', $data) && $data['function'] === null) {
+            $object->setFunction(null);
+        }
+        if (\array_key_exists('operation', $data) && $data['operation'] !== null) {
+            $value = $data['operation'];
+            if (is_string($data['operation'])) {
+                $value = $data['operation'];
+            } elseif (is_null($data['operation'])) {
+                $value = $data['operation'];
+            }
+            $object->setOperation($value);
+        }
+        elseif (\array_key_exists('operation', $data) && $data['operation'] === null) {
+            $object->setOperation(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['type'] = $data->getType();
+        if ($data->isInitialized('value')) {
+            $dataArray['value'] = $data->getValue();
+        }
+        if ($data->isInitialized('factor') && null !== $data->getFactor()) {
+            $dataArray['factor'] = $data->getFactor();
+        }
+        if ($data->isInitialized('center')) {
+            $dataArray['center'] = $data->getCenter();
+        }
+        if ($data->isInitialized('function')) {
+            $dataArray['function'] = $data->getFunction();
+        }
+        if ($data->isInitialized('operation')) {
+            $value = $data->getOperation();
+            if (is_string($data->getOperation())) {
+                $value = $data->getOperation();
+            } elseif (is_null($data->getOperation())) {
+                $value = $data->getOperation();
+            }
+            $dataArray['operation'] = $value;
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Silverstripe\Search\Client\Model\SearchRequestBoost::class => false];
+    }
+}

--- a/src/Normalizer/SearchRequestNormalizer.php
+++ b/src/Normalizer/SearchRequestNormalizer.php
@@ -27,47 +27,55 @@ class SearchRequestNormalizer implements DenormalizerInterface, NormalizerInterf
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SearchRequest();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
+        if (\array_key_exists('record_analytics', $data) && \is_int($data['record_analytics'])) {
+            $data['record_analytics'] = (bool) $data['record_analytics'];
         }
         if (\array_key_exists('query', $data)) {
             $object->setQuery($data['query']);
-            unset($data['query']);
         }
-        if (\array_key_exists('sort', $data)) {
+        if (\array_key_exists('sort', $data) && $data['sort'] !== null) {
             $value = $data['sort'];
             if (is_null($data['sort'])) {
                 $value = $data['sort'];
             }
             $object->setSort($value);
-            unset($data['sort']);
         }
-        if (\array_key_exists('page', $data)) {
+        elseif (\array_key_exists('sort', $data) && $data['sort'] === null) {
+            $object->setSort(null);
+        }
+        if (\array_key_exists('page', $data) && $data['page'] !== null) {
             $value_1 = $data['page'];
             if (is_array($data['page'])) {
-                $value_1 = $this->denormalizer->denormalize($data['page'], \Silverstripe\Search\Client\Model\PaginationNoTotals::class, 'json', $context);
+                $value_1 = $this->denormalizer->denormalize($data['page'], \Silverstripe\Search\Client\Model\SearchRequestPagination::class, 'json', $context);
             } elseif (is_null($data['page'])) {
                 $value_1 = $data['page'];
             }
             $object->setPage($value_1);
-            unset($data['page']);
         }
-        if (\array_key_exists('search_fields', $data)) {
+        elseif (\array_key_exists('page', $data) && $data['page'] === null) {
+            $object->setPage(null);
+        }
+        if (\array_key_exists('search_fields', $data) && $data['search_fields'] !== null) {
             $value_2 = $data['search_fields'];
             if (is_null($data['search_fields'])) {
                 $value_2 = $data['search_fields'];
             }
             $object->setSearchFields($value_2);
-            unset($data['search_fields']);
         }
-        if (\array_key_exists('result_fields', $data)) {
+        elseif (\array_key_exists('search_fields', $data) && $data['search_fields'] === null) {
+            $object->setSearchFields(null);
+        }
+        if (\array_key_exists('result_fields', $data) && $data['result_fields'] !== null) {
             $value_3 = $data['result_fields'];
             if (is_array($data['result_fields']) && $this->isOnlyNumericKeys($data['result_fields'])) {
                 $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
@@ -79,16 +87,24 @@ class SearchRequestNormalizer implements DenormalizerInterface, NormalizerInterf
                 $value_3 = $data['result_fields'];
             }
             $object->setResultFields($value_3);
-            unset($data['result_fields']);
         }
-        if (\array_key_exists('facets', $data)) {
+        elseif (\array_key_exists('result_fields', $data) && $data['result_fields'] === null) {
+            $object->setResultFields(null);
+        }
+        if (\array_key_exists('facets', $data) && $data['facets'] !== null) {
             $value_5 = $data['facets'];
             if (is_array($data['facets']) && $this->isOnlyNumericKeys($data['facets'])) {
                 $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
                 foreach ($data['facets'] as $key_1 => $value_6) {
                     $values_2 = [];
                     foreach ($value_6 as $value_7) {
-                        $values_2[] = $value_7;
+                        $value_8 = $value_7;
+                        if (is_array($value_7) and (isset($value_7['type']) and ($value_7['type'] == 'value' or $value_7['type'] == 'range'))) {
+                            $value_8 = $this->denormalizer->denormalize($value_7, \Silverstripe\Search\Client\Model\RequestFacetValue::class, 'json', $context);
+                        } elseif (is_array($value_7) and (isset($value_7['type']) and ($value_7['type'] == 'value' or $value_7['type'] == 'range')) and isset($value_7['ranges'])) {
+                            $value_8 = $this->denormalizer->denormalize($value_7, \Silverstripe\Search\Client\Model\RequestFacetRange::class, 'json', $context);
+                        }
+                        $values_2[] = $value_8;
                     }
                     $values_1[$key_1] = $values_2;
                 }
@@ -97,32 +113,42 @@ class SearchRequestNormalizer implements DenormalizerInterface, NormalizerInterf
                 $value_5 = $data['facets'];
             }
             $object->setFacets($value_5);
-            unset($data['facets']);
         }
-        if (\array_key_exists('filters', $data)) {
-            $value_8 = $data['filters'];
+        elseif (\array_key_exists('facets', $data) && $data['facets'] === null) {
+            $object->setFacets(null);
+        }
+        if (\array_key_exists('filters', $data) && $data['filters'] !== null) {
+            $value_9 = $data['filters'];
             if (is_array($data['filters'])) {
-                $value_8 = $this->denormalizer->denormalize($data['filters'], \Silverstripe\Search\Client\Model\Filters::class, 'json', $context);
+                $value_9 = $this->denormalizer->denormalize($data['filters'], \Silverstripe\Search\Client\Model\Filters::class, 'json', $context);
             } elseif (is_null($data['filters'])) {
-                $value_8 = $data['filters'];
+                $value_9 = $data['filters'];
             }
-            $object->setFilters($value_8);
-            unset($data['filters']);
+            $object->setFilters($value_9);
         }
-        if (\array_key_exists('analytics', $data)) {
-            $value_9 = $data['analytics'];
+        elseif (\array_key_exists('filters', $data) && $data['filters'] === null) {
+            $object->setFilters(null);
+        }
+        if (\array_key_exists('boosts', $data) && $data['boosts'] !== null) {
+            $object->setBoosts($data['boosts']);
+        }
+        elseif (\array_key_exists('boosts', $data) && $data['boosts'] === null) {
+            $object->setBoosts(null);
+        }
+        if (\array_key_exists('analytics', $data) && $data['analytics'] !== null) {
+            $value_10 = $data['analytics'];
             if (is_array($data['analytics']) and isset($data['analytics']['tags'])) {
-                $value_9 = $this->denormalizer->denormalize($data['analytics'], \Silverstripe\Search\Client\Model\Tags::class, 'json', $context);
+                $value_10 = $this->denormalizer->denormalize($data['analytics'], \Silverstripe\Search\Client\Model\Tags::class, 'json', $context);
             } elseif (is_null($data['analytics'])) {
-                $value_9 = $data['analytics'];
+                $value_10 = $data['analytics'];
             }
-            $object->setAnalytics($value_9);
-            unset($data['analytics']);
+            $object->setAnalytics($value_10);
         }
-        foreach ($data as $key_2 => $value_10) {
-            if (preg_match('/.*/', (string) $key_2)) {
-                $object[$key_2] = $value_10;
-            }
+        elseif (\array_key_exists('analytics', $data) && $data['analytics'] === null) {
+            $object->setAnalytics(null);
+        }
+        if (\array_key_exists('record_analytics', $data)) {
+            $object->setRecordAnalytics($data['record_analytics']);
         }
         return $object;
     }
@@ -130,35 +156,35 @@ class SearchRequestNormalizer implements DenormalizerInterface, NormalizerInterf
     {
         $dataArray = [];
         $dataArray['query'] = $data->getQuery();
-        if ($data->isInitialized('sort') && null !== $data->getSort()) {
+        if ($data->isInitialized('sort')) {
             $value = $data->getSort();
             if (is_null($data->getSort())) {
                 $value = $data->getSort();
             }
             $dataArray['sort'] = $value;
         }
-        if ($data->isInitialized('page') && null !== $data->getPage()) {
+        if ($data->isInitialized('page')) {
             $value_1 = $data->getPage();
             if (is_object($data->getPage())) {
-                $value_1 = $data->getPage() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getPage(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                $value_1 = $this->normalizer->normalize($data->getPage(), 'json', $context);
             } elseif (is_null($data->getPage())) {
                 $value_1 = $data->getPage();
             }
             $dataArray['page'] = $value_1;
         }
-        if ($data->isInitialized('searchFields') && null !== $data->getSearchFields()) {
+        if ($data->isInitialized('searchFields')) {
             $value_2 = $data->getSearchFields();
             if (is_null($data->getSearchFields())) {
                 $value_2 = $data->getSearchFields();
             }
             $dataArray['search_fields'] = $value_2;
         }
-        if ($data->isInitialized('resultFields') && null !== $data->getResultFields()) {
+        if ($data->isInitialized('resultFields')) {
             $value_3 = $data->getResultFields();
             if (is_object($data->getResultFields())) {
-                $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+                $values = [];
                 foreach ($data->getResultFields() as $key => $value_4) {
-                    $values[$key] = $value_4 == null ? null : new \ArrayObject($this->normalizer->normalize($value_4, 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                    $values[$key] = $this->normalizer->normalize($value_4, 'json', $context);
                 }
                 $value_3 = $values;
             } elseif (is_null($data->getResultFields())) {
@@ -166,14 +192,20 @@ class SearchRequestNormalizer implements DenormalizerInterface, NormalizerInterf
             }
             $dataArray['result_fields'] = $value_3;
         }
-        if ($data->isInitialized('facets') && null !== $data->getFacets()) {
+        if ($data->isInitialized('facets')) {
             $value_5 = $data->getFacets();
             if (is_object($data->getFacets())) {
-                $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+                $values_1 = [];
                 foreach ($data->getFacets() as $key_1 => $value_6) {
                     $values_2 = [];
                     foreach ($value_6 as $value_7) {
-                        $values_2[] = $value_7;
+                        $value_8 = $value_7;
+                        if (is_object($value_7)) {
+                            $value_8 = $this->normalizer->normalize($value_7, 'json', $context);
+                        } elseif (is_object($value_7)) {
+                            $value_8 = $this->normalizer->normalize($value_7, 'json', $context);
+                        }
+                        $values_2[] = $value_8;
                     }
                     $values_1[$key_1] = $values_2;
                 }
@@ -183,28 +215,29 @@ class SearchRequestNormalizer implements DenormalizerInterface, NormalizerInterf
             }
             $dataArray['facets'] = $value_5;
         }
-        if ($data->isInitialized('filters') && null !== $data->getFilters()) {
-            $value_8 = $data->getFilters();
+        if ($data->isInitialized('filters')) {
+            $value_9 = $data->getFilters();
             if (is_object($data->getFilters())) {
-                $value_8 = $data->getFilters() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getFilters(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                $value_9 = $this->normalizer->normalize($data->getFilters(), 'json', $context);
             } elseif (is_null($data->getFilters())) {
-                $value_8 = $data->getFilters();
+                $value_9 = $data->getFilters();
             }
-            $dataArray['filters'] = $value_8;
+            $dataArray['filters'] = $value_9;
         }
-        if ($data->isInitialized('analytics') && null !== $data->getAnalytics()) {
-            $value_9 = $data->getAnalytics();
+        if ($data->isInitialized('boosts')) {
+            $dataArray['boosts'] = $data->getBoosts();
+        }
+        if ($data->isInitialized('analytics')) {
+            $value_10 = $data->getAnalytics();
             if (is_object($data->getAnalytics())) {
-                $value_9 = $data->getAnalytics() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getAnalytics(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                $value_10 = $this->normalizer->normalize($data->getAnalytics(), 'json', $context);
             } elseif (is_null($data->getAnalytics())) {
-                $value_9 = $data->getAnalytics();
+                $value_10 = $data->getAnalytics();
             }
-            $dataArray['analytics'] = $value_9;
+            $dataArray['analytics'] = $value_10;
         }
-        foreach ($data as $key_2 => $value_10) {
-            if (preg_match('/.*/', (string) $key_2)) {
-                $dataArray[$key_2] = $value_10;
-            }
+        if ($data->isInitialized('recordAnalytics') && null !== $data->getRecordAnalytics()) {
+            $dataArray['record_analytics'] = $data->getRecordAnalytics();
         }
         return $dataArray;
     }

--- a/src/Normalizer/SearchRequestPaginationNormalizer.php
+++ b/src/Normalizer/SearchRequestPaginationNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class PaginationWithTotalsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class SearchRequestPaginationNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,63 +19,45 @@ class PaginationWithTotalsNormalizer implements DenormalizerInterface, Normalize
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Silverstripe\Search\Client\Model\PaginationWithTotals::class;
+        return $type === \Silverstripe\Search\Client\Model\SearchRequestPagination::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\PaginationWithTotals::class;
+        return is_object($data) && get_class($data) === \Silverstripe\Search\Client\Model\SearchRequestPagination::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchRequestPagination();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\PaginationWithTotals();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('current', $data)) {
             $object->setCurrent($data['current']);
-            unset($data['current']);
         }
         if (\array_key_exists('size', $data)) {
             $object->setSize($data['size']);
-            unset($data['size']);
-        }
-        if (\array_key_exists('total_pages', $data)) {
-            $object->setTotalPages($data['total_pages']);
-            unset($data['total_pages']);
-        }
-        if (\array_key_exists('total_results', $data)) {
-            $object->setTotalResults($data['total_results']);
-            unset($data['total_results']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        $dataArray['current'] = $data->getCurrent();
-        $dataArray['size'] = $data->getSize();
-        $dataArray['total_pages'] = $data->getTotalPages();
-        $dataArray['total_results'] = $data->getTotalResults();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
+        if ($data->isInitialized('current') && null !== $data->getCurrent()) {
+            $dataArray['current'] = $data->getCurrent();
+        }
+        if ($data->isInitialized('size') && null !== $data->getSize()) {
+            $dataArray['size'] = $data->getSize();
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Silverstripe\Search\Client\Model\PaginationWithTotals::class => false];
+        return [\Silverstripe\Search\Client\Model\SearchRequestPagination::class => false];
     }
 }

--- a/src/Normalizer/SearchRequestResultFieldNormalizer.php
+++ b/src/Normalizer/SearchRequestResultFieldNormalizer.php
@@ -27,17 +27,17 @@ class SearchRequestResultFieldNormalizer implements DenormalizerInterface, Norma
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchRequestResultField();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SearchRequestResultField();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('raw', $data)) {
+        if (\array_key_exists('raw', $data) && $data['raw'] !== null) {
             $value = $data['raw'];
             if (is_array($data['raw'])) {
                 $value = $this->denormalizer->denormalize($data['raw'], \Silverstripe\Search\Client\Model\SearchRequestResultFieldRaw::class, 'json', $context);
@@ -45,9 +45,11 @@ class SearchRequestResultFieldNormalizer implements DenormalizerInterface, Norma
                 $value = $data['raw'];
             }
             $object->setRaw($value);
-            unset($data['raw']);
         }
-        if (\array_key_exists('snippet', $data)) {
+        elseif (\array_key_exists('raw', $data) && $data['raw'] === null) {
+            $object->setRaw(null);
+        }
+        if (\array_key_exists('snippet', $data) && $data['snippet'] !== null) {
             $value_1 = $data['snippet'];
             if (is_array($data['snippet'])) {
                 $value_1 = $this->denormalizer->denormalize($data['snippet'], \Silverstripe\Search\Client\Model\SearchRequestResultFieldSnippet::class, 'json', $context);
@@ -55,40 +57,32 @@ class SearchRequestResultFieldNormalizer implements DenormalizerInterface, Norma
                 $value_1 = $data['snippet'];
             }
             $object->setSnippet($value_1);
-            unset($data['snippet']);
         }
-        foreach ($data as $key => $value_2) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_2;
-            }
+        elseif (\array_key_exists('snippet', $data) && $data['snippet'] === null) {
+            $object->setSnippet(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('raw') && null !== $data->getRaw()) {
+        if ($data->isInitialized('raw')) {
             $value = $data->getRaw();
             if (is_object($data->getRaw())) {
-                $value = $data->getRaw() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getRaw(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                $value = $this->normalizer->normalize($data->getRaw(), 'json', $context);
             } elseif (is_null($data->getRaw())) {
                 $value = $data->getRaw();
             }
             $dataArray['raw'] = $value;
         }
-        if ($data->isInitialized('snippet') && null !== $data->getSnippet()) {
+        if ($data->isInitialized('snippet')) {
             $value_1 = $data->getSnippet();
             if (is_object($data->getSnippet())) {
-                $value_1 = $data->getSnippet() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getSnippet(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                $value_1 = $this->normalizer->normalize($data->getSnippet(), 'json', $context);
             } elseif (is_null($data->getSnippet())) {
                 $value_1 = $data->getSnippet();
             }
             $dataArray['snippet'] = $value_1;
-        }
-        foreach ($data as $key => $value_2) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_2;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/SearchRequestResultFieldRawNormalizer.php
+++ b/src/Normalizer/SearchRequestResultFieldRawNormalizer.php
@@ -27,37 +27,29 @@ class SearchRequestResultFieldRawNormalizer implements DenormalizerInterface, No
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchRequestResultFieldRaw();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SearchRequestResultFieldRaw();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('size', $data)) {
+        if (\array_key_exists('size', $data) && $data['size'] !== null) {
             $object->setSize($data['size']);
-            unset($data['size']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('size', $data) && $data['size'] === null) {
+            $object->setSize(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('size') && null !== $data->getSize()) {
+        if ($data->isInitialized('size')) {
             $dataArray['size'] = $data->getSize();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/SearchRequestResultFieldSnippetNormalizer.php
+++ b/src/Normalizer/SearchRequestResultFieldSnippetNormalizer.php
@@ -27,44 +27,38 @@ class SearchRequestResultFieldSnippetNormalizer implements DenormalizerInterface
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchRequestResultFieldSnippet();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SearchRequestResultFieldSnippet();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('size', $data)) {
+        if (\array_key_exists('size', $data) && $data['size'] !== null) {
             $object->setSize($data['size']);
-            unset($data['size']);
         }
-        if (\array_key_exists('fallback', $data)) {
+        elseif (\array_key_exists('size', $data) && $data['size'] === null) {
+            $object->setSize(null);
+        }
+        if (\array_key_exists('fallback', $data) && $data['fallback'] !== null) {
             $object->setFallback($data['fallback']);
-            unset($data['fallback']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('fallback', $data) && $data['fallback'] === null) {
+            $object->setFallback(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('size') && null !== $data->getSize()) {
+        if ($data->isInitialized('size')) {
             $dataArray['size'] = $data->getSize();
         }
-        if ($data->isInitialized('fallback') && null !== $data->getFallback()) {
+        if ($data->isInitialized('fallback')) {
             $dataArray['fallback'] = $data->getFallback();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/SearchRequestSearchFieldsWeightNormalizer.php
+++ b/src/Normalizer/SearchRequestSearchFieldsWeightNormalizer.php
@@ -27,37 +27,29 @@ class SearchRequestSearchFieldsWeightNormalizer implements DenormalizerInterface
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchRequestSearchFieldsWeight();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SearchRequestSearchFieldsWeight();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('weight', $data)) {
+        if (\array_key_exists('weight', $data) && $data['weight'] !== null) {
             $object->setWeight($data['weight']);
-            unset($data['weight']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('weight', $data) && $data['weight'] === null) {
+            $object->setWeight(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('weight') && null !== $data->getWeight()) {
+        if ($data->isInitialized('weight')) {
             $dataArray['weight'] = $data->getWeight();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/SearchResponseEngineNormalizer.php
+++ b/src/Normalizer/SearchResponseEngineNormalizer.php
@@ -27,44 +27,38 @@ class SearchResponseEngineNormalizer implements DenormalizerInterface, Normalize
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchResponseEngine();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SearchResponseEngine();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('name', $data)) {
+        if (\array_key_exists('name', $data) && $data['name'] !== null) {
             $object->setName($data['name']);
-            unset($data['name']);
         }
-        if (\array_key_exists('type', $data)) {
+        elseif (\array_key_exists('name', $data) && $data['name'] === null) {
+            $object->setName(null);
+        }
+        if (\array_key_exists('type', $data) && $data['type'] !== null) {
             $object->setType($data['type']);
-            unset($data['type']);
         }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
+        elseif (\array_key_exists('type', $data) && $data['type'] === null) {
+            $object->setType(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('name') && null !== $data->getName()) {
+        if ($data->isInitialized('name')) {
             $dataArray['name'] = $data->getName();
         }
-        if ($data->isInitialized('type') && null !== $data->getType()) {
+        if ($data->isInitialized('type')) {
             $dataArray['type'] = $data->getType();
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/SearchResponseMetaNormalizer.php
+++ b/src/Normalizer/SearchResponseMetaNormalizer.php
@@ -27,25 +27,29 @@ class SearchResponseMetaNormalizer implements DenormalizerInterface, NormalizerI
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchResponseMeta();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SearchResponseMeta();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
-        if (\array_key_exists('warnings', $data)) {
+        if (\array_key_exists('warnings', $data) && $data['warnings'] !== null) {
             $object->setWarnings($data['warnings']);
-            unset($data['warnings']);
         }
-        if (\array_key_exists('precision', $data)) {
+        elseif (\array_key_exists('warnings', $data) && $data['warnings'] === null) {
+            $object->setWarnings(null);
+        }
+        if (\array_key_exists('precision', $data) && $data['precision'] !== null) {
             $object->setPrecision($data['precision']);
-            unset($data['precision']);
         }
-        if (\array_key_exists('engine', $data)) {
+        elseif (\array_key_exists('precision', $data) && $data['precision'] === null) {
+            $object->setPrecision(null);
+        }
+        if (\array_key_exists('engine', $data) && $data['engine'] !== null) {
             $value = $data['engine'];
             if (is_array($data['engine'])) {
                 $value = $this->denormalizer->denormalize($data['engine'], \Silverstripe\Search\Client\Model\SearchResponseEngine::class, 'json', $context);
@@ -53,50 +57,43 @@ class SearchResponseMetaNormalizer implements DenormalizerInterface, NormalizerI
                 $value = $data['engine'];
             }
             $object->setEngine($value);
-            unset($data['engine']);
         }
-        if (\array_key_exists('request_id', $data)) {
+        elseif (\array_key_exists('engine', $data) && $data['engine'] === null) {
+            $object->setEngine(null);
+        }
+        if (\array_key_exists('request_id', $data) && $data['request_id'] !== null) {
             $object->setRequestId($data['request_id']);
-            unset($data['request_id']);
+        }
+        elseif (\array_key_exists('request_id', $data) && $data['request_id'] === null) {
+            $object->setRequestId(null);
         }
         if (\array_key_exists('page', $data)) {
-            $object->setPage($this->denormalizer->denormalize($data['page'], \Silverstripe\Search\Client\Model\PaginationWithTotals::class, 'json', $context));
-            unset($data['page']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
+            $object->setPage($this->denormalizer->denormalize($data['page'], \Silverstripe\Search\Client\Model\PaginationResponse::class, 'json', $context));
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('warnings') && null !== $data->getWarnings()) {
+        if ($data->isInitialized('warnings')) {
             $dataArray['warnings'] = $data->getWarnings();
         }
-        if ($data->isInitialized('precision') && null !== $data->getPrecision()) {
+        if ($data->isInitialized('precision')) {
             $dataArray['precision'] = $data->getPrecision();
         }
-        if ($data->isInitialized('engine') && null !== $data->getEngine()) {
+        if ($data->isInitialized('engine')) {
             $value = $data->getEngine();
             if (is_object($data->getEngine())) {
-                $value = $data->getEngine() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getEngine(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+                $value = $this->normalizer->normalize($data->getEngine(), 'json', $context);
             } elseif (is_null($data->getEngine())) {
                 $value = $data->getEngine();
             }
             $dataArray['engine'] = $value;
         }
-        if ($data->isInitialized('requestId') && null !== $data->getRequestId()) {
+        if ($data->isInitialized('requestId')) {
             $dataArray['request_id'] = $data->getRequestId();
         }
-        $dataArray['page'] = $data->getPage() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getPage(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
-        }
+        $dataArray['page'] = $this->normalizer->normalize($data->getPage(), 'json', $context);
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/SearchResponseNormalizer.php
+++ b/src/Normalizer/SearchResponseNormalizer.php
@@ -27,63 +27,65 @@ class SearchResponseNormalizer implements DenormalizerInterface, NormalizerInter
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SearchResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SearchResponse();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('meta', $data)) {
             $object->setMeta($this->denormalizer->denormalize($data['meta'], \Silverstripe\Search\Client\Model\SearchResponseMeta::class, 'json', $context));
-            unset($data['meta']);
         }
         if (\array_key_exists('results', $data)) {
             $values = [];
             foreach ($data['results'] as $value) {
                 $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
                 foreach ($value as $key => $value_1) {
-                    $values_1[$key] = $value_1;
+                    $value_2 = $value_1;
+                    if (is_array($value_1)) {
+                        $value_2 = $this->denormalizer->denormalize($value_1, \Silverstripe\Search\Client\Model\DocumentResponseMeta::class, 'json', $context);
+                    } elseif (is_array($value_1)) {
+                        $value_2 = $this->denormalizer->denormalize($value_1, \Silverstripe\Search\Client\Model\DocumentField::class, 'json', $context);
+                    }
+                    $values_1[$key] = $value_2;
                 }
                 $values[] = $values_1;
             }
             $object->setResults($values);
-            unset($data['results']);
         }
-        if (\array_key_exists('facets', $data)) {
+        if (\array_key_exists('facets', $data) && $data['facets'] !== null) {
             $object->setFacets($data['facets']);
-            unset($data['facets']);
         }
-        foreach ($data as $key_1 => $value_2) {
-            if (preg_match('/.*/', (string) $key_1)) {
-                $object[$key_1] = $value_2;
-            }
+        elseif (\array_key_exists('facets', $data) && $data['facets'] === null) {
+            $object->setFacets(null);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        $dataArray['meta'] = $data->getMeta() == null ? null : new \ArrayObject($this->normalizer->normalize($data->getMeta(), 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+        $dataArray['meta'] = $this->normalizer->normalize($data->getMeta(), 'json', $context);
         $values = [];
         foreach ($data->getResults() as $value) {
-            $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+            $values_1 = [];
             foreach ($value as $key => $value_1) {
-                $values_1[$key] = $value_1;
+                $value_2 = $value_1;
+                if (is_object($value_1)) {
+                    $value_2 = $this->normalizer->normalize($value_1, 'json', $context);
+                } elseif (is_object($value_1)) {
+                    $value_2 = $this->normalizer->normalize($value_1, 'json', $context);
+                }
+                $values_1[$key] = $value_2;
             }
             $values[] = $values_1;
         }
         $dataArray['results'] = $values;
-        if ($data->isInitialized('facets') && null !== $data->getFacets()) {
+        if ($data->isInitialized('facets')) {
             $dataArray['facets'] = $data->getFacets();
-        }
-        foreach ($data as $key_1 => $value_2) {
-            if (preg_match('/.*/', (string) $key_1)) {
-                $dataArray[$key_1] = $value_2;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/SettingsRequestNormalizer.php
+++ b/src/Normalizer/SettingsRequestNormalizer.php
@@ -27,24 +27,18 @@ class SettingsRequestNormalizer implements DenormalizerInterface, NormalizerInte
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SettingsRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SettingsRequest();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('precision', $data)) {
             $object->setPrecision($data['precision']);
-            unset($data['precision']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -52,11 +46,6 @@ class SettingsRequestNormalizer implements DenormalizerInterface, NormalizerInte
     {
         $dataArray = [];
         $dataArray['precision'] = $data->getPrecision();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/SettingsResponseNormalizer.php
+++ b/src/Normalizer/SettingsResponseNormalizer.php
@@ -27,24 +27,18 @@ class SettingsResponseNormalizer implements DenormalizerInterface, NormalizerInt
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SettingsResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SettingsResponse();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('precision', $data)) {
             $object->setPrecision($data['precision']);
-            unset($data['precision']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -52,11 +46,6 @@ class SettingsResponseNormalizer implements DenormalizerInterface, NormalizerInt
     {
         $dataArray = [];
         $dataArray['precision'] = $data->getPrecision();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/SpellingSuggestionRequestNormalizer.php
+++ b/src/Normalizer/SpellingSuggestionRequestNormalizer.php
@@ -27,23 +27,21 @@ class SpellingSuggestionRequestNormalizer implements DenormalizerInterface, Norm
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SpellingSuggestionRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SpellingSuggestionRequest();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('query', $data)) {
             $object->setQuery($data['query']);
-            unset($data['query']);
         }
         if (\array_key_exists('size', $data)) {
             $object->setSize($data['size']);
-            unset($data['size']);
         }
         if (\array_key_exists('fields', $data)) {
             $values = [];
@@ -51,16 +49,12 @@ class SpellingSuggestionRequestNormalizer implements DenormalizerInterface, Norm
                 $values[] = $value;
             }
             $object->setFields($values);
-            unset($data['fields']);
         }
-        if (\array_key_exists('formatted', $data)) {
+        if (\array_key_exists('formatted', $data) && $data['formatted'] !== null) {
             $object->setFormatted($data['formatted']);
-            unset($data['formatted']);
         }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
+        elseif (\array_key_exists('formatted', $data) && $data['formatted'] === null) {
+            $object->setFormatted(null);
         }
         return $object;
     }
@@ -76,13 +70,8 @@ class SpellingSuggestionRequestNormalizer implements DenormalizerInterface, Norm
             $values[] = $value;
         }
         $dataArray['fields'] = $values;
-        if ($data->isInitialized('formatted') && null !== $data->getFormatted()) {
+        if ($data->isInitialized('formatted')) {
             $dataArray['formatted'] = $data->getFormatted();
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
         }
         return $dataArray;
     }

--- a/src/Normalizer/SpellingSuggestionResponseNormalizer.php
+++ b/src/Normalizer/SpellingSuggestionResponseNormalizer.php
@@ -27,15 +27,15 @@ class SpellingSuggestionResponseNormalizer implements DenormalizerInterface, Nor
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SpellingSuggestionResponse();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \Silverstripe\Search\Client\Model\SpellingSuggestionResponse();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('results', $data)) {
             $values = [];
@@ -43,12 +43,6 @@ class SpellingSuggestionResponseNormalizer implements DenormalizerInterface, Nor
                 $values[] = $this->denormalizer->denormalize($value, \Silverstripe\Search\Client\Model\DocumentField::class, 'json', $context);
             }
             $object->setResults($values);
-            unset($data['results']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
         }
         return $object;
     }
@@ -57,14 +51,9 @@ class SpellingSuggestionResponseNormalizer implements DenormalizerInterface, Nor
         $dataArray = [];
         $values = [];
         foreach ($data->getResults() as $value) {
-            $values[] = $value == null ? null : new \ArrayObject($this->normalizer->normalize($value, 'json', $context), \ArrayObject::ARRAY_AS_PROPS);
+            $values[] = $this->normalizer->normalize($value, 'json', $context);
         }
         $dataArray['results'] = $values;
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/SynonymRuleNormalizer.php
+++ b/src/Normalizer/SynonymRuleNormalizer.php
@@ -27,28 +27,21 @@ class SynonymRuleNormalizer implements DenormalizerInterface, NormalizerInterfac
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SynonymRule();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SynonymRule();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);
-            unset($data['id']);
         }
         if (\array_key_exists('synonyms', $data)) {
             $object->setSynonyms($data['synonyms']);
-            unset($data['synonyms']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -57,11 +50,6 @@ class SynonymRuleNormalizer implements DenormalizerInterface, NormalizerInterfac
         $dataArray = [];
         $dataArray['id'] = $data->getId();
         $dataArray['synonyms'] = $data->getSynonyms();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/SynonymRuleRequestNormalizer.php
+++ b/src/Normalizer/SynonymRuleRequestNormalizer.php
@@ -27,24 +27,18 @@ class SynonymRuleRequestNormalizer implements DenormalizerInterface, NormalizerI
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\SynonymRuleRequest();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Silverstripe\Search\Client\Model\SynonymRuleRequest();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
-        }
         if (\array_key_exists('synonyms', $data)) {
             $object->setSynonyms($data['synonyms']);
-            unset($data['synonyms']);
-        }
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value;
-            }
         }
         return $object;
     }
@@ -52,11 +46,6 @@ class SynonymRuleRequestNormalizer implements DenormalizerInterface, NormalizerI
     {
         $dataArray = [];
         $dataArray['synonyms'] = $data->getSynonyms();
-        foreach ($data as $key => $value) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/TagsNormalizer.php
+++ b/src/Normalizer/TagsNormalizer.php
@@ -27,15 +27,15 @@ class TagsNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\Tags();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \Silverstripe\Search\Client\Model\Tags();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('tags', $data)) {
             $values = [];
@@ -43,12 +43,6 @@ class TagsNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
                 $values[] = $value;
             }
             $object->setTags($values);
-            unset($data['tags']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
         }
         return $object;
     }
@@ -60,11 +54,6 @@ class TagsNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $values[] = $value;
         }
         $dataArray['tags'] = $values;
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Normalizer/ValidationErrorNormalizer.php
+++ b/src/Normalizer/ValidationErrorNormalizer.php
@@ -27,15 +27,15 @@ class ValidationErrorNormalizer implements DenormalizerInterface, NormalizerInte
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        if (isset($data['$ref'])) {
+        $object = new \Silverstripe\Search\Client\Model\ValidationError();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
             return new Reference($data['$ref'], $context['document-origin']);
         }
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
-        }
-        $object = new \Silverstripe\Search\Client\Model\ValidationError();
-        if (null === $data || false === \is_array($data)) {
-            return $object;
         }
         if (\array_key_exists('loc', $data)) {
             $values = [];
@@ -43,20 +43,12 @@ class ValidationErrorNormalizer implements DenormalizerInterface, NormalizerInte
                 $values[] = $value;
             }
             $object->setLoc($values);
-            unset($data['loc']);
         }
         if (\array_key_exists('msg', $data)) {
             $object->setMsg($data['msg']);
-            unset($data['msg']);
         }
         if (\array_key_exists('type', $data)) {
             $object->setType($data['type']);
-            unset($data['type']);
-        }
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $object[$key] = $value_1;
-            }
         }
         return $object;
     }
@@ -70,11 +62,6 @@ class ValidationErrorNormalizer implements DenormalizerInterface, NormalizerInte
         $dataArray['loc'] = $values;
         $dataArray['msg'] = $data->getMsg();
         $dataArray['type'] = $data->getType();
-        foreach ($data as $key => $value_1) {
-            if (preg_match('/.*/', (string) $key)) {
-                $dataArray[$key] = $value_1;
-            }
-        }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array

--- a/src/Runtime/Client/BaseEndpoint.php
+++ b/src/Runtime/Client/BaseEndpoint.php
@@ -27,7 +27,13 @@ abstract class BaseEndpoint implements Endpoint
         $optionsResolved = array_map(static function ($value) {
             return $value ?? '';
         }, $optionsResolved);
-        return http_build_query($optionsResolved, '', '&', \PHP_QUERY_RFC3986);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
     }
     public function getHeaders(array $baseHeaders = []): array
     {
@@ -36,6 +42,10 @@ abstract class BaseEndpoint implements Endpoint
     protected function getQueryOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
     }
     protected function getHeadersOptionsResolver(): OptionsResolver
     {
@@ -63,5 +73,35 @@ abstract class BaseEndpoint implements Endpoint
     protected function getSerializedBody(SerializerInterface $serializer): array
     {
         return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
     }
 }


### PR DESCRIPTION
## Previous fixes applied

This fix to use serialiser:
https://github.com/silverstripeltd/jane-php-open-api-3/commit/71cbb12279ba37b02bdfc1fc26e21fd9ea755173

Is now in the source under the new 3.1 Generator:
https://github.com/janephp/janephp/blob/next/src/Component/OpenApi31/Generator/RequestBodyContent/JsonBodyContentGenerator.php

## Previous fixes NOT applied

This fix has not been applied at the source, so we might need to fork and apply again:
https://github.com/silverstripeltd/jane-php-json-schema/commit/6a7b26690068ba0d19c744a9b8e7abd4622be513