### PR TITLE
AOS-591: Add query-time precision override to SearchRequest

### DIFF
--- a/src/Request/Search/SearchRequest.php
+++ b/src/Request/Search/SearchRequest.php
@@ -54,6 +54,12 @@ class SearchRequest implements JsonSerializable
 
     private bool $recordAnalytics = true;
 
+    /**
+     * Override the engine precision for this request only. Valid values are 1 - 11 (inclusive). When null, the engine's
+     * configured precision (set in the dashboard) is used.
+     */
+    private ?int $precision = null;
+
     public function __construct(private readonly string $query)
     {
     }
@@ -299,6 +305,18 @@ class SearchRequest implements JsonSerializable
         return $this;
     }
 
+    public function getPrecision(): ?int
+    {
+        return $this->precision;
+    }
+
+    public function setPrecision(?int $precision): static
+    {
+        $this->precision = $precision;
+
+        return $this;
+    }
+
     public function jsonSerialize(): array
     {
         $payload = [
@@ -343,6 +361,10 @@ class SearchRequest implements JsonSerializable
 
         if ($this->analytics !== null) {
             $payload['analytics'] = $this->analytics;
+        }
+
+        if ($this->precision !== null) {
+            $payload['precision'] = $this->precision;
         }
 
         $payload['record_analytics'] = $this->recordAnalytics;

--- a/tests/Request/Search/SearchRequestTest.php
+++ b/tests/Request/Search/SearchRequestTest.php
@@ -336,6 +336,44 @@ class SearchRequestTest extends TestCase
         $this->assertFalse($result['record_analytics']);
     }
 
+    // Precision tests
+
+    public function testPrecisionDefaultsToNull(): void
+    {
+        $request = new SearchRequest('test');
+
+        $this->assertNull($request->getPrecision());
+    }
+
+    public function testPrecisionOmittedFromPayloadWhenNull(): void
+    {
+        $request = new SearchRequest('test');
+
+        $this->assertArrayNotHasKey('precision', $request->jsonSerialize());
+    }
+
+    public function testSetPrecision(): void
+    {
+        $request = new SearchRequest('test');
+        $request->setPrecision(10);
+
+        $this->assertSame(10, $request->getPrecision());
+
+        $result = $request->jsonSerialize();
+
+        $this->assertSame(10, $result['precision']);
+    }
+
+    public function testSetPrecisionNull(): void
+    {
+        $request = new SearchRequest('test');
+        $request->setPrecision(10);
+        $request->setPrecision(null);
+
+        $this->assertNull($request->getPrecision());
+        $this->assertArrayNotHasKey('precision', $request->jsonSerialize());
+    }
+
     // Full payload test
 
     public function testFullPayload(): void
@@ -357,10 +395,12 @@ class SearchRequestTest extends TestCase
 
         $request->setAnalytics(new Tags(['search-page']));
         $request->setRecordAnalytics(true);
+        $request->setPrecision(7);
 
         $result = json_decode(json_encode($request), true);
 
         $this->assertSame('full test', $result['query']);
+        $this->assertSame(7, $result['precision']);
         $this->assertArrayHasKey('sort', $result);
         $this->assertArrayHasKey('page', $result);
         $this->assertArrayHasKey('search_fields', $result);
@@ -392,6 +432,8 @@ class SearchRequestTest extends TestCase
         $this->assertSame($request, $request->setBoosts(null));
         $this->assertSame($request, $request->setAnalytics(null));
         $this->assertSame($request, $request->setRecordAnalytics(true));
+        $this->assertSame($request, $request->setPrecision(5));
+        $this->assertSame($request, $request->setPrecision(null));
     }
 
 }


### PR DESCRIPTION
## What

Adds an optional `precision` property (1–11) to `SearchRequest`.

- `getPrecision()` / `setPrecision(?int)` accessors (fluent setter).
- Serialised as `precision` in the search payload **only when set**. When `null`, the field is omitted and the engine uses its dashboard-configured precision.

The Bifröst search endpoint already accepts a per-request `precision` (`body.precision or engine.search_precision`); this exposes it in the PHP client.

## Why

Lets callers override the engine precision per query (e.g. a precision selector on a search page) without changing the engine-wide setting. Part of AOS-591.

## Tests

- Added precision coverage to `SearchRequestTest` (default null, omitted-when-null, set/serialise, null-after-set, fluent setter, full payload).
- Full suite green locally: `OK (34 tests, 78 assertions)`.

## Related

- silverstripe-discoverer: AOS-591 (Query precision)
- silverstripe-discoverer-bifrost: AOS-591 (pass-through)
